### PR TITLE
Dependency Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
     - Renaming of meta-model namespace URI to: `https://mdsd.tools/jamopp/java`
 - Upgraded dependency versions to:
     - Apache Commons Bytecode Engineering Library 6.7.0
-	- Apache Log4j 2 2.20.0 including the Log4j 1.x bridge
+	- Apache Log4j 2 2.20.0
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Migration to MDSD Tools organization
     - Converted Maven Tycho-based build to pure Maven build
     - Unification and renaming of packages to: `tools.mdsd.jamopp`
-    - Renaming of meta-model namespace URI to: `https://mdsd.tools/jamopp/java`
+    - Renaming of meta-model namespace URI to: `https://mdsd.tools/jamopp/6.0.0/java`
+    - Versioned the meta-model
 - Upgraded dependency versions to:
     - Apache Commons Bytecode Engineering Library 6.7.0
 	- Apache Log4j 2 2.20.0

--- a/jamopp.model.edit/.gitignore
+++ b/jamopp.model.edit/.gitignore
@@ -1,2 +1,5 @@
 /src/main/generated
 /src/main/resources
+build.properties
+plugin.properties
+plugin.xml

--- a/jamopp.model.edit/pom.xml
+++ b/jamopp.model.edit/pom.xml
@@ -97,6 +97,11 @@
                         <goals>
                             <goal>bundle</goal>
                         </goals>
+                        <configuration>
+							<instructions>
+								<Bundle-SymbolicName>${project.groupId}.${project.artifactId};singleton:=true</Bundle-SymbolicName>
+							</instructions>
+						</configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/jamopp.model/.gitignore
+++ b/jamopp.model/.gitignore
@@ -1,1 +1,4 @@
 /src/main/generated
+build.properties
+plugin.properties
+plugin.xml

--- a/jamopp.model/pom.xml
+++ b/jamopp.model/pom.xml
@@ -64,6 +64,11 @@
                         <goals>
                             <goal>bundle</goal>
                         </goals>
+                        <configuration>
+							<instructions>
+								<Bundle-SymbolicName>${project.groupId}.${project.artifactId};singleton:=true</Bundle-SymbolicName>
+							</instructions>
+						</configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/jamopp.model/src/main/java/tools/mdsd/jamopp/model/java/JavaPackage.java
+++ b/jamopp.model/src/main/java/tools/mdsd/jamopp/model/java/JavaPackage.java
@@ -47,7 +47,7 @@ public interface JavaPackage extends EPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	String eNS_URI = "http://www.emftext.org/java";
+	String eNS_URI = "https://mdsd.tools/jamopp/6.0.0/java";
 
 	/**
 	 * The package namespace name.

--- a/jamopp.model/src/main/resources/metamodel/java.ecore
+++ b/jamopp.model/src/main/resources/metamodel/java.ecore
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmi:id="_WosmsNz1Ed2bJ_pQViWxFg" name="java" nsURI="https://mdsd.tools/jamopp/java"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmi:id="_WosmsNz1Ed2bJ_pQViWxFg" name="java" nsURI="https://mdsd.tools/jamopp/6.0.0/java"
     nsPrefix="java">
-  <eSubpackages xmi:id="_Wosmsdz1Ed2bJ_pQViWxFg" name="annotations" nsURI="https://mdsd.tools/jamopp/java/annotations"
+  <eSubpackages xmi:id="_Wosmsdz1Ed2bJ_pQViWxFg" name="annotations" nsURI="https://mdsd.tools/jamopp/6.0.0/java/annotations"
       nsPrefix="annotations">
     <eClassifiers xsi:type="ecore:EClass" name="Annotable" abstract="true" eSuperTypes="#//commons/Commentable">
       <eStructuralFeatures xsi:type="ecore:EReference" name="annotations" upperBound="-1"
@@ -34,7 +34,8 @@
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="AnnotationValue" abstract="true" eSuperTypes="#//commons/Commentable"/>
   </eSubpackages>
-  <eSubpackages name="arrays" nsURI="https://mdsd.tools/jamopp/java/arrays" nsPrefix="arrays">
+  <eSubpackages name="arrays" nsURI="https://mdsd.tools/jamopp/6.0.0/java/arrays"
+      nsPrefix="arrays">
     <eClassifiers xsi:type="ecore:EClass" name="ArrayTypeable" abstract="true" eSuperTypes="#//commons/Commentable">
       <eOperations name="getArrayDimension" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//ELong">
         <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -83,7 +84,7 @@
           containment="true"/>
     </eClassifiers>
   </eSubpackages>
-  <eSubpackages name="classifiers" nsURI="https://mdsd.tools/jamopp/java/classifiers"
+  <eSubpackages name="classifiers" nsURI="https://mdsd.tools/jamopp/6.0.0/java/classifiers"
       nsPrefix="classifiers">
     <eClassifiers xsi:type="ecore:EClass" name="Classifier" abstract="true" eSuperTypes="#_Wo2ZO9z1Ed2bJ_pQViWxFg #//references/ReferenceableElement">
       <eOperations name="getAllSuperClassifiers" upperBound="-1" eType="#//classifiers/ConcreteClassifier">
@@ -241,7 +242,8 @@
       </eOperations>
     </eClassifiers>
   </eSubpackages>
-  <eSubpackages name="commons" nsURI="https://mdsd.tools/jamopp/java/commons" nsPrefix="commons">
+  <eSubpackages name="commons" nsURI="https://mdsd.tools/jamopp/6.0.0/java/commons"
+      nsPrefix="commons">
     <eClassifiers xsi:type="ecore:EClass" name="Commentable" abstract="true">
       <eOperations name="getConcreteClassifier" eType="#//classifiers/ConcreteClassifier">
         <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -437,7 +439,7 @@
           upperBound="-1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     </eClassifiers>
   </eSubpackages>
-  <eSubpackages name="containers" nsURI="https://mdsd.tools/jamopp/java/containers"
+  <eSubpackages name="containers" nsURI="https://mdsd.tools/jamopp/6.0.0/java/containers"
       nsPrefix="containers">
     <eClassifiers xsi:type="ecore:EClass" name="JavaRoot" abstract="true" eSuperTypes="#//commons/NamedElement #//commons/NamespaceAwareElement #//imports/ImportingElement #//annotations/Annotable">
       <eOperations name="getClassifiersInSamePackage" upperBound="-1" eType="#//classifiers/ConcreteClassifier">
@@ -525,7 +527,7 @@
       <eLiterals name="BINDING" value="3"/>
     </eClassifiers>
   </eSubpackages>
-  <eSubpackages xmi:id="_Wo2YC9z1Ed2bJ_pQViWxFg" name="expressions" nsURI="https://mdsd.tools/jamopp/java/expressions"
+  <eSubpackages xmi:id="_Wo2YC9z1Ed2bJ_pQViWxFg" name="expressions" nsURI="https://mdsd.tools/jamopp/6.0.0/java/expressions"
       nsPrefix="expressions">
     <eClassifiers xsi:type="ecore:EClass" xmi:id="_Wo2YF9z1Ed2bJ_pQViWxFg" name="ExpressionList"
         eSuperTypes="#_Wo2Y9tz1Ed2bJ_pQViWxFg">
@@ -797,7 +799,8 @@
     <eClassifiers xsi:type="ecore:EClass" name="ImplicitlyTypedLambdaParameters" eSuperTypes="#//expressions/LambdaParameters"/>
     <eClassifiers xsi:type="ecore:EClass" name="SingleImplicitLambdaParameter" eSuperTypes="#//expressions/ImplicitlyTypedLambdaParameters"/>
   </eSubpackages>
-  <eSubpackages name="generics" nsURI="https://mdsd.tools/jamopp/java/generics" nsPrefix="generics">
+  <eSubpackages name="generics" nsURI="https://mdsd.tools/jamopp/6.0.0/java/generics"
+      nsPrefix="generics">
     <eClassifiers xsi:type="ecore:EClass" name="TypeArgument" abstract="true" eSuperTypes="#//arrays/ArrayTypeable"/>
     <eClassifiers xsi:type="ecore:EClass" name="TypeArgumentable" abstract="true"
         eSuperTypes="#//commons/Commentable">
@@ -865,7 +868,8 @@
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="UnknownTypeArgument" eSuperTypes="#//generics/TypeArgument #//annotations/Annotable"/>
   </eSubpackages>
-  <eSubpackages name="imports" nsURI="https://mdsd.tools/jamopp/java/imports" nsPrefix="imports">
+  <eSubpackages name="imports" nsURI="https://mdsd.tools/jamopp/6.0.0/java/imports"
+      nsPrefix="imports">
     <eClassifiers xsi:type="ecore:EClass" name="Import" abstract="true" eSuperTypes="#//commons/NamespaceAwareElement">
       <eOperations name="getImportedClassifier" eType="#//classifiers/ConcreteClassifier">
         <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -904,7 +908,7 @@
           upperBound="-1" eType="#//references/ReferenceableElement"/>
     </eClassifiers>
   </eSubpackages>
-  <eSubpackages name="instantiations" nsURI="https://mdsd.tools/jamopp/java/instantiations"
+  <eSubpackages name="instantiations" nsURI="https://mdsd.tools/jamopp/6.0.0/java/instantiations"
       nsPrefix="instantiations">
     <eClassifiers xsi:type="ecore:EClass" name="Initializable" abstract="true" eSuperTypes="#//commons/Commentable">
       <eStructuralFeatures xsi:type="ecore:EReference" name="initialValue" eType="#_Wo2YDNz1Ed2bJ_pQViWxFg"
@@ -922,7 +926,7 @@
           eType="#//literals/Self" containment="true"/>
     </eClassifiers>
   </eSubpackages>
-  <eSubpackages xmi:id="_Wo2Yntz1Ed2bJ_pQViWxFg" name="literals" nsURI="https://mdsd.tools/jamopp/java/literals"
+  <eSubpackages xmi:id="_Wo2Yntz1Ed2bJ_pQViWxFg" name="literals" nsURI="https://mdsd.tools/jamopp/6.0.0/java/literals"
       nsPrefix="literals">
     <eClassifiers xsi:type="ecore:EClass" xmi:id="_Wo2YsNz1Ed2bJ_pQViWxFg" name="Literal"
         abstract="true" eSuperTypes="#//expressions/PrimaryExpression">
@@ -1004,7 +1008,8 @@
     <eClassifiers xsi:type="ecore:EClass" name="Super" eSuperTypes="#//literals/Self"/>
     <eClassifiers xsi:type="ecore:EClass" name="This" eSuperTypes="#//literals/Self"/>
   </eSubpackages>
-  <eSubpackages name="members" nsURI="https://mdsd.tools/jamopp/java/members" nsPrefix="members">
+  <eSubpackages name="members" nsURI="https://mdsd.tools/jamopp/6.0.0/java/members"
+      nsPrefix="members">
     <eClassifiers xsi:type="ecore:EClass" name="ExceptionThrower" abstract="true"
         eSuperTypes="#//commons/Commentable">
       <eStructuralFeatures xsi:type="ecore:EReference" name="exceptions" upperBound="-1"
@@ -1155,7 +1160,7 @@
           containment="true"/>
     </eClassifiers>
   </eSubpackages>
-  <eSubpackages xmi:id="_Wo2Ystz1Ed2bJ_pQViWxFg" name="modifiers" nsURI="https://mdsd.tools/jamopp/java/modifiers"
+  <eSubpackages xmi:id="_Wo2Ystz1Ed2bJ_pQViWxFg" name="modifiers" nsURI="https://mdsd.tools/jamopp/6.0.0/java/modifiers"
       nsPrefix="modifiers">
     <eClassifiers xsi:type="ecore:EClass" xmi:id="_Wo2Ys9z1Ed2bJ_pQViWxFg" name="Modifier"
         abstract="true" eSuperTypes="#//modifiers/AnnotationInstanceOrModifier"/>
@@ -1294,7 +1299,7 @@
         eSuperTypes="#//commons/Commentable"/>
     <eClassifiers xsi:type="ecore:EClass" name="Open" eSuperTypes="#//commons/Commentable"/>
   </eSubpackages>
-  <eSubpackages name="operators" nsURI="https://mdsd.tools/jamopp/java/operators"
+  <eSubpackages name="operators" nsURI="https://mdsd.tools/jamopp/6.0.0/java/operators"
       nsPrefix="operators">
     <eClassifiers xsi:type="ecore:EClass" name="Operator" abstract="true" eSuperTypes="#//commons/Commentable"/>
     <eClassifiers xsi:type="ecore:EClass" name="AdditiveOperator" abstract="true"
@@ -1342,7 +1347,7 @@
     <eClassifiers xsi:type="ecore:EClass" name="RightShift" eSuperTypes="#//operators/ShiftOperator"/>
     <eClassifiers xsi:type="ecore:EClass" name="UnsignedRightShift" eSuperTypes="#//operators/ShiftOperator"/>
   </eSubpackages>
-  <eSubpackages name="parameters" nsURI="https://mdsd.tools/jamopp/java/parameters"
+  <eSubpackages name="parameters" nsURI="https://mdsd.tools/jamopp/6.0.0/java/parameters"
       nsPrefix="parameters">
     <eClassifiers xsi:type="ecore:EClass" name="Parameter" abstract="true" eSuperTypes="#//variables/Variable #//modifiers/AnnotableAndModifiable"/>
     <eClassifiers xsi:type="ecore:EClass" name="Parametrizable" abstract="true" eSuperTypes="#//commons/Commentable">
@@ -1362,7 +1367,7 @@
           eType="#//literals/This" containment="true"/>
     </eClassifiers>
   </eSubpackages>
-  <eSubpackages name="references" nsURI="https://mdsd.tools/jamopp/java/references"
+  <eSubpackages name="references" nsURI="https://mdsd.tools/jamopp/6.0.0/java/references"
       nsPrefix="references">
     <eClassifiers xsi:type="ecore:EClass" name="Reference" abstract="true" eSuperTypes="#//expressions/PrimaryExpression #//generics/TypeArgumentable #//types/TypedElementExtension">
       <eOperations name="getReferencedType" eType="#_Wo2ZO9z1Ed2bJ_pQViWxFg">
@@ -1433,7 +1438,7 @@
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="PackageReference" eSuperTypes="#//references/ReferenceableElement #//commons/NamespaceAwareElement"/>
   </eSubpackages>
-  <eSubpackages xmi:id="_Wo2Yy9z1Ed2bJ_pQViWxFg" name="statements" nsURI="https://mdsd.tools/jamopp/java/statements"
+  <eSubpackages xmi:id="_Wo2Yy9z1Ed2bJ_pQViWxFg" name="statements" nsURI="https://mdsd.tools/jamopp/6.0.0/java/statements"
       nsPrefix="statements">
     <eClassifiers xsi:type="ecore:EClass" name="StatementContainer" abstract="true"
         eSuperTypes="#//commons/Commentable">
@@ -1612,7 +1617,7 @@
           upperBound="-1" eType="#_Wo2YDNz1Ed2bJ_pQViWxFg" containment="true"/>
     </eClassifiers>
   </eSubpackages>
-  <eSubpackages xmi:id="_Wo2ZOtz1Ed2bJ_pQViWxFg" name="types" nsURI="https://mdsd.tools/jamopp/java/types"
+  <eSubpackages xmi:id="_Wo2ZOtz1Ed2bJ_pQViWxFg" name="types" nsURI="https://mdsd.tools/jamopp/6.0.0/java/types"
       nsPrefix="types">
     <eClassifiers xsi:type="ecore:EClass" xmi:id="_Wo2ZO9z1Ed2bJ_pQViWxFg" name="Type"
         abstract="true" eSuperTypes="#//commons/Commentable">
@@ -1739,7 +1744,7 @@
       </eOperations>
     </eClassifiers>
   </eSubpackages>
-  <eSubpackages name="variables" nsURI="https://mdsd.tools/jamopp/java/variables"
+  <eSubpackages name="variables" nsURI="https://mdsd.tools/jamopp/6.0.0/java/variables"
       nsPrefix="variables">
     <eClassifiers xsi:type="ecore:EClass" name="Variable" abstract="true" eSuperTypes="#//commons/NamedElement #_Wo2ZP9z1Ed2bJ_pQViWxFg #//references/ReferenceableElement #//generics/TypeArgumentable">
       <eOperations name="createMethodCallStatement" eType="#_Wo2YzNz1Ed2bJ_pQViWxFg">
@@ -1767,7 +1772,8 @@
     <eClassifiers xsi:type="ecore:EClass" name="Resource" abstract="true" interface="true"
         eSuperTypes="#//commons/Commentable"/>
   </eSubpackages>
-  <eSubpackages name="modules" nsURI="https://mdsd.tools/jamopp/java/modules" nsPrefix="modules">
+  <eSubpackages name="modules" nsURI="https://mdsd.tools/jamopp/6.0.0/java/modules"
+      nsPrefix="modules">
     <eClassifiers xsi:type="ecore:EClass" name="ModuleDirective" abstract="true" eSuperTypes="#//commons/Commentable"/>
     <eClassifiers xsi:type="ecore:EClass" name="UsesModuleDirective" eSuperTypes="#//modules/ModuleDirective #_Wo2ZP9z1Ed2bJ_pQViWxFg"/>
     <eClassifiers xsi:type="ecore:EClass" name="ProvidesModuleDirective" eSuperTypes="#_Wo2ZP9z1Ed2bJ_pQViWxFg #//modules/ModuleDirective">
@@ -1792,7 +1798,8 @@
       <eStructuralFeatures xsi:type="ecore:EReference" name="target" eType="#//containers/Module"/>
     </eClassifiers>
   </eSubpackages>
-  <eSubpackages name="layout" nsURI="https://mdsd.tools/jamopp/commons/layout" nsPrefix="layout">
+  <eSubpackages name="layout" nsURI="https://mdsd.tools/jamopp/6.0.0/commons/layout"
+      nsPrefix="layout">
     <eClassifiers xsi:type="ecore:EClass" name="LayoutInformation" abstract="true">
       <eStructuralFeatures xsi:type="ecore:EAttribute" name="startOffset" lowerBound="1"
           eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>

--- a/jamopp.model/src/main/resources/metamodel/java.genmodel
+++ b/jamopp.model/src/main/resources/metamodel/java.genmodel
@@ -40,7 +40,7 @@
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//arrays/ArrayTypeable/arrayDimensionsBefore"/>
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//arrays/ArrayTypeable/arrayDimensionsAfter"/>
         <genOperations ecoreOperation="java.ecore#//arrays/ArrayTypeable/getArrayDimension"
-            body="return tools.mdsd.jamopp.model.extensions.arrays.ArrayTypeableExtension.getArrayDimension((tools.mdsd.jamopp.model.arrays.ArrayTypeable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.arrays.ArrayTypeableExtension.getArrayDimension((tools.mdsd.jamopp.model.java.arrays.ArrayTypeable) this);"/>
       </genClasses>
       <genClasses ecoreClass="java.ecore#//arrays/ArrayDimension"/>
       <genClasses ecoreClass="java.ecore#//arrays/ArrayInitializer">
@@ -51,7 +51,7 @@
       <genClasses ecoreClass="java.ecore#//arrays/ArrayInstantiationBySize">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//arrays/ArrayInstantiationBySize/sizes"/>
         <genOperations ecoreOperation="java.ecore#//arrays/ArrayInstantiationBySize/getArrayDimension"
-            body="return tools.mdsd.jamopp.model.extensions.expressions.ExpressionExtension.getArrayDimension((tools.mdsd.jamopp.model.expressions.Expression) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.expressions.ExpressionExtension.getArrayDimension((tools.mdsd.jamopp.model.java.expressions.Expression) this);"/>
       </genClasses>
       <genClasses image="false" ecoreClass="java.ecore#//arrays/ArrayInstantiationByValues">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//arrays/ArrayInstantiationByValues/arrayInitializer"/>
@@ -59,7 +59,7 @@
       <genClasses ecoreClass="java.ecore#//arrays/ArrayInstantiationByValuesUntyped"/>
       <genClasses ecoreClass="java.ecore#//arrays/ArrayInstantiationByValuesTyped">
         <genOperations ecoreOperation="java.ecore#//arrays/ArrayInstantiationByValuesTyped/getArrayDimension"
-            body="return tools.mdsd.jamopp.model.extensions.expressions.ExpressionExtension.getArrayDimension((tools.mdsd.jamopp.model.expressions.Expression) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.expressions.ExpressionExtension.getArrayDimension((tools.mdsd.jamopp.model.java.expressions.Expression) this);"/>
       </genClasses>
       <genClasses ecoreClass="java.ecore#//arrays/ArraySelector">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//arrays/ArraySelector/position"/>
@@ -69,32 +69,32 @@
         disposableProviderFactory="true" ecorePackage="java.ecore#//classifiers">
       <genClasses image="false" ecoreClass="java.ecore#//classifiers/Classifier">
         <genOperations ecoreOperation="java.ecore#//classifiers/Classifier/getAllSuperClassifiers"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.ClassifierExtension.getAllSuperClassifiers((tools.mdsd.jamopp.model.classifiers.Classifier) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.ClassifierExtension.getAllSuperClassifiers((tools.mdsd.jamopp.model.java.classifiers.Classifier) this);"/>
         <genOperations ecoreOperation="java.ecore#//classifiers/Classifier/addImport"
-            body="tools.mdsd.jamopp.model.extensions.classifiers.ClassifierExtension.addImport((tools.mdsd.jamopp.model.classifiers.Classifier) this, nameOfClassToImport);">
+            body="tools.mdsd.jamopp.model.java.extensions.classifiers.ClassifierExtension.addImport((tools.mdsd.jamopp.model.java.classifiers.Classifier) this, nameOfClassToImport);">
           <genParameters ecoreParameter="java.ecore#//classifiers/Classifier/addImport/nameOfClassToImport"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//classifiers/Classifier/addPackageImport"
-            body="tools.mdsd.jamopp.model.extensions.classifiers.ClassifierExtension.addPackageImport((tools.mdsd.jamopp.model.classifiers.Classifier) this, packageName);">
+            body="tools.mdsd.jamopp.model.java.extensions.classifiers.ClassifierExtension.addPackageImport((tools.mdsd.jamopp.model.java.classifiers.Classifier) this, packageName);">
           <genParameters ecoreParameter="java.ecore#//classifiers/Classifier/addPackageImport/packageName"/>
         </genOperations>
       </genClasses>
       <genClasses image="false" ecoreClass="java.ecore#//classifiers/ConcreteClassifier">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//classifiers/ConcreteClassifier/package"/>
         <genOperations ecoreOperation="java.ecore#//classifiers/ConcreteClassifier/getInnerClassifiers"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.ConcreteClassifierExtension.getInnerClassifiers((tools.mdsd.jamopp.model.classifiers.ConcreteClassifier) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.ConcreteClassifierExtension.getInnerClassifiers((tools.mdsd.jamopp.model.java.classifiers.ConcreteClassifier) this);"/>
         <genOperations ecoreOperation="java.ecore#//classifiers/ConcreteClassifier/getAllInnerClassifiers"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.ConcreteClassifierExtension.getAllInnerClassifiers((tools.mdsd.jamopp.model.classifiers.ConcreteClassifier) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.ConcreteClassifierExtension.getAllInnerClassifiers((tools.mdsd.jamopp.model.java.classifiers.ConcreteClassifier) this);"/>
         <genOperations ecoreOperation="java.ecore#//classifiers/ConcreteClassifier/getSuperTypeReferences"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.ConcreteClassifierExtension.getSuperTypeReferences((tools.mdsd.jamopp.model.classifiers.ConcreteClassifier) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.ConcreteClassifierExtension.getSuperTypeReferences((tools.mdsd.jamopp.model.java.classifiers.ConcreteClassifier) this);"/>
         <genOperations ecoreOperation="java.ecore#//classifiers/ConcreteClassifier/getAllMembers"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.ConcreteClassifierExtension.getAllMembers((tools.mdsd.jamopp.model.classifiers.ConcreteClassifier) this, (tools.mdsd.jamopp.model.commons.Commentable) context);">
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.ConcreteClassifierExtension.getAllMembers((tools.mdsd.jamopp.model.java.classifiers.ConcreteClassifier) this, (tools.mdsd.jamopp.model.java.commons.Commentable) context);">
           <genParameters ecoreParameter="java.ecore#//classifiers/ConcreteClassifier/getAllMembers/context"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//classifiers/ConcreteClassifier/getQualifiedName"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.ConcreteClassifierExtension.getQualifiedName((tools.mdsd.jamopp.model.classifiers.ConcreteClassifier) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.ConcreteClassifierExtension.getQualifiedName((tools.mdsd.jamopp.model.java.classifiers.ConcreteClassifier) this);"/>
         <genOperations ecoreOperation="java.ecore#//classifiers/ConcreteClassifier/isJavaLangObject"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.ConcreteClassifierExtension.isJavaLangObject((tools.mdsd.jamopp.model.classifiers.ConcreteClassifier) clazz);">
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.ConcreteClassifierExtension.isJavaLangObject((tools.mdsd.jamopp.model.java.classifiers.ConcreteClassifier) clazz);">
           <genParameters ecoreParameter="java.ecore#//classifiers/ConcreteClassifier/isJavaLangObject/clazz"/>
         </genOperations>
       </genClasses>
@@ -105,40 +105,40 @@
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//classifiers/Class/extends"/>
         <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference java.ecore#//classifiers/Class/defaultExtends"/>
         <genOperations ecoreOperation="java.ecore#//classifiers/Class/getAllSuperClassifiers"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.ClassExtension.getAllSuperClassifiers((tools.mdsd.jamopp.model.classifiers.Class) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.ClassExtension.getAllSuperClassifiers((tools.mdsd.jamopp.model.java.classifiers.Class) this);"/>
         <genOperations ecoreOperation="java.ecore#//classifiers/Class/getSuperClass"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.ClassExtension.getSuperClass((tools.mdsd.jamopp.model.classifiers.Class) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.ClassExtension.getSuperClass((tools.mdsd.jamopp.model.java.classifiers.Class) this);"/>
         <genOperations ecoreOperation="java.ecore#//classifiers/Class/unWrapPrimitiveType"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.ClassExtension.unWrapPrimitiveType((tools.mdsd.jamopp.model.classifiers.Class) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.ClassExtension.unWrapPrimitiveType((tools.mdsd.jamopp.model.java.classifiers.Class) this);"/>
       </genClasses>
       <genClasses ecoreClass="java.ecore#//classifiers/Interface">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//classifiers/Interface/extends"/>
         <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference java.ecore#//classifiers/Interface/defaultExtends"/>
         <genOperations ecoreOperation="java.ecore#//classifiers/Interface/getAllSuperClassifiers"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.InterfaceExtension.getAllSuperClassifiers((tools.mdsd.jamopp.model.classifiers.Interface) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.InterfaceExtension.getAllSuperClassifiers((tools.mdsd.jamopp.model.java.classifiers.Interface) this);"/>
         <genOperations ecoreOperation="java.ecore#//classifiers/Interface/getAbstractMethodOfFunctionalInterface"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.InterfaceExtension.getAbstractMethodOfFunctionalInterface((tools.mdsd.jamopp.model.classifiers.Interface) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.InterfaceExtension.getAbstractMethodOfFunctionalInterface((tools.mdsd.jamopp.model.java.classifiers.Interface) this);"/>
       </genClasses>
       <genClasses ecoreClass="java.ecore#//classifiers/Enumeration">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//classifiers/Enumeration/constants"/>
         <genOperations ecoreOperation="java.ecore#//classifiers/Enumeration/getAllSuperClassifiers"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.EnumerationExtension.getAllSuperClassifiers((tools.mdsd.jamopp.model.classifiers.Enumeration) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.EnumerationExtension.getAllSuperClassifiers((tools.mdsd.jamopp.model.java.classifiers.Enumeration) this);"/>
         <genOperations ecoreOperation="java.ecore#//classifiers/Enumeration/getContainedConstant"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.EnumerationExtension.getContainedConstant((tools.mdsd.jamopp.model.classifiers.Enumeration) this, name);">
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.EnumerationExtension.getContainedConstant((tools.mdsd.jamopp.model.java.classifiers.Enumeration) this, name);">
           <genParameters ecoreParameter="java.ecore#//classifiers/Enumeration/getContainedConstant/name"/>
         </genOperations>
       </genClasses>
       <genClasses ecoreClass="java.ecore#//classifiers/Annotation">
         <genOperations ecoreOperation="java.ecore#//classifiers/Annotation/getAllSuperClassifiers"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.AnnotationExtension.getAllSuperClassifiers((tools.mdsd.jamopp.model.classifiers.Annotation) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.AnnotationExtension.getAllSuperClassifiers((tools.mdsd.jamopp.model.java.classifiers.Annotation) this);"/>
       </genClasses>
       <genClasses ecoreClass="java.ecore#//classifiers/AnonymousClass">
         <genOperations ecoreOperation="java.ecore#//classifiers/AnonymousClass/getAllSuperClassifiers"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.AnonymousClassExtension.getAllSuperClassifiers((tools.mdsd.jamopp.model.classifiers.AnonymousClass) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.AnonymousClassExtension.getAllSuperClassifiers((tools.mdsd.jamopp.model.java.classifiers.AnonymousClass) this);"/>
         <genOperations ecoreOperation="java.ecore#//classifiers/AnonymousClass/getSuperClassifier"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.AnonymousClassExtension.getSuperClassifier((tools.mdsd.jamopp.model.classifiers.AnonymousClass) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.AnonymousClassExtension.getSuperClassifier((tools.mdsd.jamopp.model.java.classifiers.AnonymousClass) this);"/>
         <genOperations ecoreOperation="java.ecore#//classifiers/AnonymousClass/getAllMembers"
-            body="return tools.mdsd.jamopp.model.extensions.classifiers.AnonymousClassExtension.getAllMembers((tools.mdsd.jamopp.model.classifiers.AnonymousClass) this, (tools.mdsd.jamopp.model.commons.Commentable) context);">
+            body="return tools.mdsd.jamopp.model.java.extensions.classifiers.AnonymousClassExtension.getAllMembers((tools.mdsd.jamopp.model.java.classifiers.AnonymousClass) this, (tools.mdsd.jamopp.model.java.commons.Commentable) context);">
           <genParameters ecoreParameter="java.ecore#//classifiers/AnonymousClass/getAllMembers/context"/>
         </genOperations>
       </genClasses>
@@ -148,77 +148,77 @@
       <genClasses image="false" ecoreClass="java.ecore#//commons/Commentable">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//commons/Commentable/layoutInformations"/>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getConcreteClassifier"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getConcreteClassifier((tools.mdsd.jamopp.model.commons.Commentable) this, name);">
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getConcreteClassifier((tools.mdsd.jamopp.model.java.commons.Commentable) this, name);">
           <genParameters ecoreParameter="java.ecore#//commons/Commentable/getConcreteClassifier/name"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getConcreteClassifiers"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getConcreteClassifiers((tools.mdsd.jamopp.model.commons.Commentable) this, packageName, classifierQuery);">
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getConcreteClassifiers((tools.mdsd.jamopp.model.java.commons.Commentable) this, packageName, classifierQuery);">
           <genParameters ecoreParameter="java.ecore#//commons/Commentable/getConcreteClassifiers/packageName"/>
           <genParameters ecoreParameter="java.ecore#//commons/Commentable/getConcreteClassifiers/classifierQuery"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getLibClass"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getLibClass((tools.mdsd.jamopp.model.commons.Commentable) this, name);">
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getLibClass((tools.mdsd.jamopp.model.java.commons.Commentable) this, name);">
           <genParameters ecoreParameter="java.ecore#//commons/Commentable/getLibClass/name"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getLibInterface"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getLibInterface((tools.mdsd.jamopp.model.commons.Commentable) this, name);">
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getLibInterface((tools.mdsd.jamopp.model.java.commons.Commentable) this, name);">
           <genParameters ecoreParameter="java.ecore#//commons/Commentable/getLibInterface/name"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getClassClass"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getClassClass((tools.mdsd.jamopp.model.commons.Commentable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getClassClass((tools.mdsd.jamopp.model.java.commons.Commentable) this);"/>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getObjectClass"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getObjectClass((tools.mdsd.jamopp.model.commons.Commentable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getObjectClass((tools.mdsd.jamopp.model.java.commons.Commentable) this);"/>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getStringClass"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getStringClass((tools.mdsd.jamopp.model.commons.Commentable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getStringClass((tools.mdsd.jamopp.model.java.commons.Commentable) this);"/>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getAnnotationInterface"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getAnnotationInterface((tools.mdsd.jamopp.model.commons.Commentable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getAnnotationInterface((tools.mdsd.jamopp.model.java.commons.Commentable) this);"/>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getContainingAnnotationInstance"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getContainingAnnotationInstance((tools.mdsd.jamopp.model.commons.Commentable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getContainingAnnotationInstance((tools.mdsd.jamopp.model.java.commons.Commentable) this);"/>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getContainingAnonymousClass"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getContainingAnonymousClass((tools.mdsd.jamopp.model.commons.Commentable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getContainingAnonymousClass((tools.mdsd.jamopp.model.java.commons.Commentable) this);"/>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getContainingConcreteClassifier"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getContainingConcreteClassifier((tools.mdsd.jamopp.model.commons.Commentable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getContainingConcreteClassifier((tools.mdsd.jamopp.model.java.commons.Commentable) this);"/>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getContainingCompilationUnit"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getContainingCompilationUnit((tools.mdsd.jamopp.model.commons.Commentable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getContainingCompilationUnit((tools.mdsd.jamopp.model.java.commons.Commentable) this);"/>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getContainingPackageName"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getContainingPackageName((tools.mdsd.jamopp.model.commons.Commentable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getContainingPackageName((tools.mdsd.jamopp.model.java.commons.Commentable) this);"/>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getContainingContainerName"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getContainingContainerName((tools.mdsd.jamopp.model.commons.Commentable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getContainingContainerName((tools.mdsd.jamopp.model.java.commons.Commentable) this);"/>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getParentConcreteClassifier"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getParentConcreteClassifier((tools.mdsd.jamopp.model.commons.Commentable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getParentConcreteClassifier((tools.mdsd.jamopp.model.java.commons.Commentable) this);"/>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getParentByEType"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getParentByEType((tools.mdsd.jamopp.model.commons.Commentable) this, (org.eclipse.emf.ecore.EClass) type);">
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getParentByEType((tools.mdsd.jamopp.model.java.commons.Commentable) this, (org.eclipse.emf.ecore.EClass) type);">
           <genParameters ecoreParameter="java.ecore#//commons/Commentable/getParentByEType/type"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getFirstChildByEType"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getFirstChildByEType((tools.mdsd.jamopp.model.commons.Commentable) this, (org.eclipse.emf.ecore.EClass) type);">
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getFirstChildByEType((tools.mdsd.jamopp.model.java.commons.Commentable) this, (org.eclipse.emf.ecore.EClass) type);">
           <genParameters ecoreParameter="java.ecore#//commons/Commentable/getFirstChildByEType/type"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getParentByType"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getParentByType((tools.mdsd.jamopp.model.commons.Commentable) this, type);">
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getParentByType((tools.mdsd.jamopp.model.java.commons.Commentable) this, type);">
           <genParameters ecoreParameter="java.ecore#//commons/Commentable/getParentByType/type"/>
           <genTypeParameters ecoreTypeParameter="java.ecore#//commons/Commentable/getParentByType/T"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getFirstChildByType"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getFirstChildByType((tools.mdsd.jamopp.model.commons.Commentable) this, ( java.lang.Class&lt;T>) type);">
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getFirstChildByType((tools.mdsd.jamopp.model.java.commons.Commentable) this, ( java.lang.Class&lt;T>) type);">
           <genParameters ecoreParameter="java.ecore#//commons/Commentable/getFirstChildByType/type"/>
           <genTypeParameters ecoreTypeParameter="java.ecore#//commons/Commentable/getFirstChildByType/T"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getChildrenByEType"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getChildrenByEType((tools.mdsd.jamopp.model.commons.Commentable) this, (org.eclipse.emf.ecore.EClass) type);">
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getChildrenByEType((tools.mdsd.jamopp.model.java.commons.Commentable) this, (org.eclipse.emf.ecore.EClass) type);">
           <genParameters ecoreParameter="java.ecore#//commons/Commentable/getChildrenByEType/type"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/getChildrenByType"
-            body="return tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.getChildrenByType((tools.mdsd.jamopp.model.commons.Commentable) this, ( java.lang.Class&lt;T>) type);">
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.getChildrenByType((tools.mdsd.jamopp.model.java.commons.Commentable) this, ( java.lang.Class&lt;T>) type);">
           <genParameters ecoreParameter="java.ecore#//commons/Commentable/getChildrenByType/type"/>
           <genTypeParameters ecoreTypeParameter="java.ecore#//commons/Commentable/getChildrenByType/T"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/addBeforeContainingStatement"
-            body="tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.addBeforeContainingStatement((tools.mdsd.jamopp.model.commons.Commentable) this, (tools.mdsd.jamopp.model.statements.Statement) statementToAdd);">
+            body="tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.addBeforeContainingStatement((tools.mdsd.jamopp.model.java.commons.Commentable) this, (tools.mdsd.jamopp.model.java.statements.Statement) statementToAdd);">
           <genParameters ecoreParameter="java.ecore#//commons/Commentable/addBeforeContainingStatement/statementToAdd"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//commons/Commentable/addAfterContainingStatement"
-            body="tools.mdsd.jamopp.model.extensions.commons.CommentableExtension.addAfterContainingStatement((tools.mdsd.jamopp.model.commons.Commentable) this, (tools.mdsd.jamopp.model.statements.Statement) statementToAdd);">
+            body="tools.mdsd.jamopp.model.java.extensions.commons.CommentableExtension.addAfterContainingStatement((tools.mdsd.jamopp.model.java.commons.Commentable) this, (tools.mdsd.jamopp.model.java.statements.Statement) statementToAdd);">
           <genParameters ecoreParameter="java.ecore#//commons/Commentable/addAfterContainingStatement/statementToAdd"/>
         </genOperations>
       </genClasses>
@@ -228,9 +228,9 @@
       <genClasses image="false" ecoreClass="java.ecore#//commons/NamespaceAwareElement">
         <genFeatures createChild="false" ecoreFeature="ecore:EAttribute java.ecore#//commons/NamespaceAwareElement/namespaces"/>
         <genOperations ecoreOperation="java.ecore#//commons/NamespaceAwareElement/getNamespacesAsString"
-            body="return tools.mdsd.jamopp.model.extensions.commons.NamespaceAwareElementExtension.getNamespacesAsString((tools.mdsd.jamopp.model.commons.NamespaceAwareElement) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.NamespaceAwareElementExtension.getNamespacesAsString((tools.mdsd.jamopp.model.java.commons.NamespaceAwareElement) this);"/>
         <genOperations ecoreOperation="java.ecore#//commons/NamespaceAwareElement/getClassifierAtNamespaces"
-            body="return tools.mdsd.jamopp.model.extensions.commons.NamespaceAwareElementExtension.getClassifierAtNamespaces((tools.mdsd.jamopp.model.commons.NamespaceAwareElement) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.commons.NamespaceAwareElementExtension.getClassifierAtNamespaces((tools.mdsd.jamopp.model.java.commons.NamespaceAwareElement) this);"/>
       </genClasses>
     </nestedGenPackages>
     <nestedGenPackages prefix="Containers" basePackage="tools.mdsd.jamopp.model.java"
@@ -244,30 +244,30 @@
       <genClasses image="false" ecoreClass="java.ecore#//containers/JavaRoot">
         <genFeatures createChild="false" ecoreFeature="ecore:EAttribute java.ecore#//containers/JavaRoot/origin"/>
         <genOperations ecoreOperation="java.ecore#//containers/JavaRoot/getClassifiersInSamePackage"
-            body="return tools.mdsd.jamopp.model.extensions.containers.JavaRootExtension.getClassifiersInSamePackage((tools.mdsd.jamopp.model.containers.JavaRoot) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.containers.JavaRootExtension.getClassifiersInSamePackage((tools.mdsd.jamopp.model.java.containers.JavaRoot) this);"/>
       </genClasses>
       <genClasses ecoreClass="java.ecore#//containers/CompilationUnit">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//containers/CompilationUnit/classifiers"/>
         <genOperations ecoreOperation="java.ecore#//containers/CompilationUnit/getContainedClassifier"
-            body="return tools.mdsd.jamopp.model.extensions.containers.CompilationUnitExtension.getContainedClassifier((tools.mdsd.jamopp.model.containers.CompilationUnit) this, name);">
+            body="return tools.mdsd.jamopp.model.java.extensions.containers.CompilationUnitExtension.getContainedClassifier((tools.mdsd.jamopp.model.java.containers.CompilationUnit) this, name);">
           <genParameters ecoreParameter="java.ecore#//containers/CompilationUnit/getContainedClassifier/name"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//containers/CompilationUnit/getClassifiersInSamePackage"
-            body="return tools.mdsd.jamopp.model.extensions.containers.CompilationUnitExtension.getClassifiersInSamePackage((tools.mdsd.jamopp.model.containers.CompilationUnit) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.containers.CompilationUnitExtension.getClassifiersInSamePackage((tools.mdsd.jamopp.model.java.containers.CompilationUnit) this);"/>
         <genOperations ecoreOperation="java.ecore#//containers/CompilationUnit/getContainedClass"
-            body="return tools.mdsd.jamopp.model.extensions.containers.CompilationUnitExtension.getContainedClass((tools.mdsd.jamopp.model.containers.CompilationUnit) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.containers.CompilationUnitExtension.getContainedClass((tools.mdsd.jamopp.model.java.containers.CompilationUnit) this);"/>
         <genOperations ecoreOperation="java.ecore#//containers/CompilationUnit/getContainedInterface"
-            body="return tools.mdsd.jamopp.model.extensions.containers.CompilationUnitExtension.getContainedInterface((tools.mdsd.jamopp.model.containers.CompilationUnit) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.containers.CompilationUnitExtension.getContainedInterface((tools.mdsd.jamopp.model.java.containers.CompilationUnit) this);"/>
         <genOperations ecoreOperation="java.ecore#//containers/CompilationUnit/getContainedAnnotation"
-            body="return tools.mdsd.jamopp.model.extensions.containers.CompilationUnitExtension.getContainedAnnotation((tools.mdsd.jamopp.model.containers.CompilationUnit) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.containers.CompilationUnitExtension.getContainedAnnotation((tools.mdsd.jamopp.model.java.containers.CompilationUnit) this);"/>
         <genOperations ecoreOperation="java.ecore#//containers/CompilationUnit/getContainedEnumeration"
-            body="return tools.mdsd.jamopp.model.extensions.containers.CompilationUnitExtension.getContainedEnumeration((tools.mdsd.jamopp.model.containers.CompilationUnit) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.containers.CompilationUnitExtension.getContainedEnumeration((tools.mdsd.jamopp.model.java.containers.CompilationUnit) this);"/>
         <genOperations ecoreOperation="java.ecore#//containers/CompilationUnit/addImport"
-            body="tools.mdsd.jamopp.model.extensions.containers.CompilationUnitExtension.addImport((tools.mdsd.jamopp.model.containers.CompilationUnit) this, nameOfClassToImport);">
+            body="tools.mdsd.jamopp.model.java.extensions.containers.CompilationUnitExtension.addImport((tools.mdsd.jamopp.model.java.containers.CompilationUnit) this, nameOfClassToImport);">
           <genParameters ecoreParameter="java.ecore#//containers/CompilationUnit/addImport/nameOfClassToImport"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//containers/CompilationUnit/addPackageImport"
-            body="tools.mdsd.jamopp.model.extensions.containers.CompilationUnitExtension.addPackageImport((tools.mdsd.jamopp.model.containers.CompilationUnit) this, packageName);">
+            body="tools.mdsd.jamopp.model.java.extensions.containers.CompilationUnitExtension.addPackageImport((tools.mdsd.jamopp.model.java.containers.CompilationUnit) this, packageName);">
           <genParameters ecoreParameter="java.ecore#//containers/CompilationUnit/addPackageImport/packageName"/>
         </genOperations>
       </genClasses>
@@ -290,17 +290,17 @@
       </genClasses>
       <genClasses image="false" ecoreClass="java.ecore#_Wo2YDNz1Ed2bJ_pQViWxFg">
         <genOperations ecoreOperation="java.ecore#//expressions/Expression/getType"
-            body="return tools.mdsd.jamopp.model.extensions.expressions.ExpressionExtension.getType((tools.mdsd.jamopp.model.expressions.Expression) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.expressions.ExpressionExtension.getType((tools.mdsd.jamopp.model.java.expressions.Expression) this);"/>
         <genOperations ecoreOperation="java.ecore#//expressions/Expression/getAlternativeType"
-            body="return tools.mdsd.jamopp.model.extensions.expressions.ExpressionExtension.getAlternativeType((tools.mdsd.jamopp.model.expressions.Expression) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.expressions.ExpressionExtension.getAlternativeType((tools.mdsd.jamopp.model.java.expressions.Expression) this);"/>
         <genOperations ecoreOperation="java.ecore#//expressions/Expression/getOneType"
-            body="return tools.mdsd.jamopp.model.extensions.expressions.ExpressionExtension.getOneType((tools.mdsd.jamopp.model.expressions.Expression) this, alternative);">
+            body="return tools.mdsd.jamopp.model.java.extensions.expressions.ExpressionExtension.getOneType((tools.mdsd.jamopp.model.java.expressions.Expression) this, alternative);">
           <genParameters ecoreParameter="java.ecore#//expressions/Expression/getOneType/alternative"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//expressions/Expression/getArrayDimension"
-            body="return tools.mdsd.jamopp.model.extensions.expressions.ExpressionExtension.getArrayDimension((tools.mdsd.jamopp.model.expressions.Expression) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.expressions.ExpressionExtension.getArrayDimension((tools.mdsd.jamopp.model.java.expressions.Expression) this);"/>
         <genOperations ecoreOperation="java.ecore#//expressions/Expression/getOneTypeReference"
-            body="return tools.mdsd.jamopp.model.extensions.expressions.ExpressionExtension.getOneTypeReference((tools.mdsd.jamopp.model.expressions.Expression) this, alternative);">
+            body="return tools.mdsd.jamopp.model.java.extensions.expressions.ExpressionExtension.getOneTypeReference((tools.mdsd.jamopp.model.java.expressions.Expression) this, alternative);">
           <genParameters ecoreParameter="java.ecore#//expressions/Expression/getOneTypeReference/alternative"/>
         </genOperations>
       </genClasses>
@@ -315,9 +315,9 @@
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#_Wo2YJdz1Ed2bJ_pQViWxFg"/>
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//expressions/ConditionalExpression/generalExpressionElse"/>
         <genOperations ecoreOperation="java.ecore#//expressions/ConditionalExpression/getExpressionElse"
-            body="return tools.mdsd.jamopp.model.extensions.expressions.ConditionalExpressionExtension.getExpressionElse((tools.mdsd.jamopp.model.expressions.ConditionalExpression) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.expressions.ConditionalExpressionExtension.getExpressionElse((tools.mdsd.jamopp.model.java.expressions.ConditionalExpression) this);"/>
         <genOperations ecoreOperation="java.ecore#//expressions/ConditionalExpression/setExpressionChild"
-            body="tools.mdsd.jamopp.model.extensions.expressions.ConditionalExpressionExtension.setExpressionElse((tools.mdsd.jamopp.model.expressions.ConditionalExpression) this, newChild);">
+            body="tools.mdsd.jamopp.model.java.extensions.expressions.ConditionalExpressionExtension.setExpressionElse((tools.mdsd.jamopp.model.java.expressions.ConditionalExpression) this, newChild);">
           <genParameters ecoreParameter="java.ecore#//expressions/ConditionalExpression/setExpressionChild/newChild"/>
         </genOperations>
       </genClasses>
@@ -387,9 +387,9 @@
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//expressions/CastExpression/additionalBounds"/>
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#_Wo2YXdz1Ed2bJ_pQViWxFg"/>
         <genOperations ecoreOperation="java.ecore#//expressions/CastExpression/getChild"
-            body="return tools.mdsd.jamopp.model.extensions.expressions.CastExpressionExtension.getChild((tools.mdsd.jamopp.model.expressions.CastExpression) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.expressions.CastExpressionExtension.getChild((tools.mdsd.jamopp.model.java.expressions.CastExpression) this);"/>
         <genOperations ecoreOperation="java.ecore#//expressions/CastExpression/setChild"
-            body="tools.mdsd.jamopp.model.extensions.expressions.CastExpressionExtension.setChild((tools.mdsd.jamopp.model.expressions.CastExpression) this, newChild);">
+            body="tools.mdsd.jamopp.model.java.extensions.expressions.CastExpressionExtension.setChild((tools.mdsd.jamopp.model.java.expressions.CastExpression) this, newChild);">
           <genParameters ecoreParameter="java.ecore#//expressions/CastExpression/setChild/newChild"/>
         </genOperations>
       </genClasses>
@@ -399,9 +399,9 @@
       </genClasses>
       <genClasses image="false" ecoreClass="java.ecore#//expressions/MethodReferenceExpression">
         <genOperations ecoreOperation="java.ecore#//expressions/MethodReferenceExpression/getTargetType"
-            body="return tools.mdsd.jamopp.model.extensions.expressions.MethodReferenceExpressionExtension.getTargetType((MethodReferenceExpression) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.expressions.MethodReferenceExpressionExtension.getTargetType((MethodReferenceExpression) this);"/>
         <genOperations ecoreOperation="java.ecore#//expressions/MethodReferenceExpression/getTargetTypeReference"
-            body="return tools.mdsd.jamopp.model.extensions.expressions.MethodReferenceExpressionExtension.getTargetTypeReference((MethodReferenceExpression) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.expressions.MethodReferenceExpressionExtension.getTargetTypeReference((MethodReferenceExpression) this);"/>
       </genClasses>
       <genClasses ecoreClass="java.ecore#//expressions/PrimaryExpressionReferenceExpression">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//expressions/PrimaryExpressionReferenceExpression/child"/>
@@ -414,11 +414,11 @@
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//expressions/LambdaExpression/parameters"/>
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//expressions/LambdaExpression/body"/>
         <genOperations ecoreOperation="java.ecore#//expressions/LambdaExpression/doesLambdaMatchFunctionalInterface"
-            body="return tools.mdsd.jamopp.model.extensions.expressions.LambdaExpressionExtension.doesLambdaMatchFunctionalInterface((tools.mdsd.jamopp.model.expressions.LambdaExpression) this, functionalInterface);">
+            body="return tools.mdsd.jamopp.model.java.extensions.expressions.LambdaExpressionExtension.doesLambdaMatchFunctionalInterface((tools.mdsd.jamopp.model.java.expressions.LambdaExpression) this, functionalInterface);">
           <genParameters ecoreParameter="java.ecore#//expressions/LambdaExpression/doesLambdaMatchFunctionalInterface/functionalInterface"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//expressions/LambdaExpression/getReturnType"
-            body="return tools.mdsd.jamopp.model.extensions.expressions.LambdaExpressionExtension.getReturnType((tools.mdsd.jamopp.model.expressions.LambdaExpression) this, potentialReturnType);">
+            body="return tools.mdsd.jamopp.model.java.extensions.expressions.LambdaExpressionExtension.getReturnType((tools.mdsd.jamopp.model.java.expressions.LambdaExpression) this, potentialReturnType);">
           <genParameters ecoreParameter="java.ecore#//expressions/LambdaExpression/getReturnType/potentialReturnType"/>
         </genOperations>
       </genClasses>
@@ -443,7 +443,7 @@
       <genClasses ecoreClass="java.ecore#//generics/ExtendsTypeArgument">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//generics/ExtendsTypeArgument/extendType"/>
         <genOperations ecoreOperation="java.ecore#//generics/ExtendsTypeArgument/getExtendTypes"
-            body="return tools.mdsd.jamopp.model.extensions.generics.ExtendsTypeArgumentExtension.getExtendTypes((tools.mdsd.jamopp.model.generics.ExtendsTypeArgument) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.generics.ExtendsTypeArgumentExtension.getExtendTypes((tools.mdsd.jamopp.model.java.generics.ExtendsTypeArgument) this);"/>
       </genClasses>
       <genClasses ecoreClass="java.ecore#//generics/QualifiedTypeArgument"/>
       <genClasses ecoreClass="java.ecore#//generics/SuperTypeArgument">
@@ -452,18 +452,18 @@
       <genClasses ecoreClass="java.ecore#//generics/TypeParameter">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//generics/TypeParameter/extendTypes"/>
         <genOperations ecoreOperation="java.ecore#//generics/TypeParameter/getAllSuperClassifiers"
-            body="return tools.mdsd.jamopp.model.extensions.generics.TypeParameterExtension.getAllSuperClassifiers((tools.mdsd.jamopp.model.generics.TypeParameter) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.generics.TypeParameterExtension.getAllSuperClassifiers((tools.mdsd.jamopp.model.java.generics.TypeParameter) this);"/>
         <genOperations ecoreOperation="java.ecore#//generics/TypeParameter/getAllMembers"
-            body="return tools.mdsd.jamopp.model.extensions.generics.TypeParameterExtension.getAllMembers((tools.mdsd.jamopp.model.generics.TypeParameter) this, (tools.mdsd.jamopp.model.commons.Commentable) context);">
+            body="return tools.mdsd.jamopp.model.java.extensions.generics.TypeParameterExtension.getAllMembers((tools.mdsd.jamopp.model.java.generics.TypeParameter) this, (tools.mdsd.jamopp.model.java.commons.Commentable) context);">
           <genParameters ecoreParameter="java.ecore#//generics/TypeParameter/getAllMembers/context"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//generics/TypeParameter/getBoundType"
-            body="return tools.mdsd.jamopp.model.extensions.generics.TypeParameterExtension.getBoundType((tools.mdsd.jamopp.model.generics.TypeParameter) this, (tools.mdsd.jamopp.model.types.TypeReference) typeReference, (tools.mdsd.jamopp.model.references.Reference) reference);">
+            body="return tools.mdsd.jamopp.model.java.extensions.generics.TypeParameterExtension.getBoundType((tools.mdsd.jamopp.model.java.generics.TypeParameter) this, (tools.mdsd.jamopp.model.java.types.TypeReference) typeReference, (tools.mdsd.jamopp.model.java.references.Reference) reference);">
           <genParameters ecoreParameter="java.ecore#//generics/TypeParameter/getBoundType/typeReference"/>
           <genParameters ecoreParameter="java.ecore#//generics/TypeParameter/getBoundType/reference"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//generics/TypeParameter/getBoundTypeReference"
-            body="return tools.mdsd.jamopp.model.extensions.generics.TypeParameterExtension.getBoundTypeReference((tools.mdsd.jamopp.model.generics.TypeParameter) this, (tools.mdsd.jamopp.model.types.TypeReference) typeReference, (tools.mdsd.jamopp.model.references.Reference) reference);">
+            body="return tools.mdsd.jamopp.model.java.extensions.generics.TypeParameterExtension.getBoundTypeReference((tools.mdsd.jamopp.model.java.generics.TypeParameter) this, (tools.mdsd.jamopp.model.java.types.TypeReference) typeReference, (tools.mdsd.jamopp.model.java.references.Reference) reference);">
           <genParameters ecoreParameter="java.ecore#//generics/TypeParameter/getBoundTypeReference/typeReference"/>
           <genParameters ecoreParameter="java.ecore#//generics/TypeParameter/getBoundTypeReference/reference"/>
         </genOperations>
@@ -476,13 +476,13 @@
         <genFeatures notify="false" createChild="false" propertySortChoices="true"
             ecoreFeature="ecore:EReference java.ecore#//imports/Import/classifier"/>
         <genOperations ecoreOperation="java.ecore#//imports/Import/getImportedClassifier"
-            body="return tools.mdsd.jamopp.model.extensions.imports.ImportExtension.getImportedClassifier((tools.mdsd.jamopp.model.imports.Import) this, name);">
+            body="return tools.mdsd.jamopp.model.java.extensions.imports.ImportExtension.getImportedClassifier((tools.mdsd.jamopp.model.java.imports.Import) this, name);">
           <genParameters ecoreParameter="java.ecore#//imports/Import/getImportedClassifier/name"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//imports/Import/getImportedClassifiers"
-            body="return tools.mdsd.jamopp.model.extensions.imports.ImportExtension.getImportedClassifiers((tools.mdsd.jamopp.model.imports.Import) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.imports.ImportExtension.getImportedClassifiers((tools.mdsd.jamopp.model.java.imports.Import) this);"/>
         <genOperations ecoreOperation="java.ecore#//imports/Import/getImportedMembers"
-            body="return tools.mdsd.jamopp.model.extensions.imports.ImportExtension.getImportedMembers((tools.mdsd.jamopp.model.imports.Import) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.imports.ImportExtension.getImportedMembers((tools.mdsd.jamopp.model.java.imports.Import) this);"/>
       </genClasses>
       <genClasses image="false" ecoreClass="java.ecore#//imports/ImportingElement">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//imports/ImportingElement/imports"/>
@@ -515,7 +515,7 @@
     <nestedGenPackages prefix="Literals" basePackage="tools.mdsd.jamopp.model.java"
         disposableProviderFactory="true" ecorePackage="java.ecore#_Wo2Yntz1Ed2bJ_pQViWxFg">
       <genClasses image="false" ecoreClass="java.ecore#_Wo2YsNz1Ed2bJ_pQViWxFg">
-        <genOperations ecoreOperation="java.ecore#//literals/Literal/getOneType" body="return tools.mdsd.jamopp.model.extensions.literals.LiteralExtension.getOneType((tools.mdsd.jamopp.model.literals.Literal) this);">
+        <genOperations ecoreOperation="java.ecore#//literals/Literal/getOneType" body="return tools.mdsd.jamopp.model.java.extensions.literals.LiteralExtension.getOneType((tools.mdsd.jamopp.model.java.literals.Literal) this);">
           <genParameters ecoreParameter="java.ecore#//literals/Literal/getOneType/alternative"/>
         </genOperations>
       </genClasses>
@@ -580,43 +580,43 @@
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//members/MemberContainer/members"/>
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//members/MemberContainer/defaultMembers"/>
         <genOperations ecoreOperation="java.ecore#//members/MemberContainer/getContainedClassifier"
-            body="return tools.mdsd.jamopp.model.extensions.members.MemberContainerExtension.getContainedClassifier((tools.mdsd.jamopp.model.members.MemberContainer) this, name);">
+            body="return tools.mdsd.jamopp.model.java.extensions.members.MemberContainerExtension.getContainedClassifier((tools.mdsd.jamopp.model.java.members.MemberContainer) this, name);">
           <genParameters ecoreParameter="java.ecore#//members/MemberContainer/getContainedClassifier/name"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//members/MemberContainer/getContainedField"
-            body="return tools.mdsd.jamopp.model.extensions.members.MemberContainerExtension.getContainedField((tools.mdsd.jamopp.model.members.MemberContainer) this, name);">
+            body="return tools.mdsd.jamopp.model.java.extensions.members.MemberContainerExtension.getContainedField((tools.mdsd.jamopp.model.java.members.MemberContainer) this, name);">
           <genParameters ecoreParameter="java.ecore#//members/MemberContainer/getContainedField/name"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//members/MemberContainer/getContainedMethod"
-            body="return tools.mdsd.jamopp.model.extensions.members.MemberContainerExtension.getContainedMethod((tools.mdsd.jamopp.model.members.MemberContainer) this, name);">
+            body="return tools.mdsd.jamopp.model.java.extensions.members.MemberContainerExtension.getContainedMethod((tools.mdsd.jamopp.model.java.members.MemberContainer) this, name);">
           <genParameters ecoreParameter="java.ecore#//members/MemberContainer/getContainedMethod/name"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//members/MemberContainer/getMethods"
-            body="return tools.mdsd.jamopp.model.extensions.members.MemberContainerExtension.getMethods((tools.mdsd.jamopp.model.members.MemberContainer) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.members.MemberContainerExtension.getMethods((tools.mdsd.jamopp.model.java.members.MemberContainer) this);"/>
         <genOperations ecoreOperation="java.ecore#//members/MemberContainer/removeMethods"
-            body="tools.mdsd.jamopp.model.extensions.members.MemberContainerExtension.removeMethods((tools.mdsd.jamopp.model.members.MemberContainer) this, name);">
+            body="tools.mdsd.jamopp.model.java.extensions.members.MemberContainerExtension.removeMethods((tools.mdsd.jamopp.model.java.members.MemberContainer) this, name);">
           <genParameters ecoreParameter="java.ecore#//members/MemberContainer/removeMethods/name"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//members/MemberContainer/getMembersByName"
-            body="return tools.mdsd.jamopp.model.extensions.members.MemberContainerExtension.getMembersByName((tools.mdsd.jamopp.model.members.MemberContainer) this, name);">
+            body="return tools.mdsd.jamopp.model.java.extensions.members.MemberContainerExtension.getMembersByName((tools.mdsd.jamopp.model.java.members.MemberContainer) this, name);">
           <genParameters ecoreParameter="java.ecore#//members/MemberContainer/getMembersByName/name"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//members/MemberContainer/createField"
-            body="return tools.mdsd.jamopp.model.extensions.members.MemberContainerExtension.createField((tools.mdsd.jamopp.model.members.MemberContainer) this, name, qualifiedTypeName);">
+            body="return tools.mdsd.jamopp.model.java.extensions.members.MemberContainerExtension.createField((tools.mdsd.jamopp.model.java.members.MemberContainer) this, name, qualifiedTypeName);">
           <genParameters ecoreParameter="java.ecore#//members/MemberContainer/createField/name"/>
           <genParameters ecoreParameter="java.ecore#//members/MemberContainer/createField/qualifiedTypeName"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//members/MemberContainer/getFields"
-            body="return tools.mdsd.jamopp.model.extensions.members.MemberContainerExtension.getFields((tools.mdsd.jamopp.model.members.MemberContainer) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.members.MemberContainerExtension.getFields((tools.mdsd.jamopp.model.java.members.MemberContainer) this);"/>
         <genOperations ecoreOperation="java.ecore#//members/MemberContainer/getConstructors"
-            body="return tools.mdsd.jamopp.model.extensions.members.MemberContainerExtension.getConstructors((tools.mdsd.jamopp.model.members.MemberContainer) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.members.MemberContainerExtension.getConstructors((tools.mdsd.jamopp.model.java.members.MemberContainer) this);"/>
       </genClasses>
       <genClasses ecoreClass="java.ecore#//members/AdditionalField"/>
       <genClasses ecoreClass="java.ecore#//members/Constructor">
         <genOperations ecoreOperation="java.ecore#//members/Constructor/getStatements"
-            body="return tools.mdsd.jamopp.model.extensions.members.ConstructorExtension.getStatements((tools.mdsd.jamopp.model.members.Constructor) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.members.ConstructorExtension.getStatements((tools.mdsd.jamopp.model.java.members.Constructor) this);"/>
         <genOperations ecoreOperation="java.ecore#//members/Constructor/isConstructorForCall"
-            body="return tools.mdsd.jamopp.model.extensions.members.ConstructorExtension.isConstructorForCall((Constructor) this, call, needsPerfectMatch);">
+            body="return tools.mdsd.jamopp.model.java.extensions.members.ConstructorExtension.isConstructorForCall((Constructor) this, call, needsPerfectMatch);">
           <genParameters ecoreParameter="java.ecore#//members/Constructor/isConstructorForCall/call"/>
           <genParameters ecoreParameter="java.ecore#//members/Constructor/isConstructorForCall/needsPerfectMatch"/>
         </genOperations>
@@ -627,24 +627,24 @@
       </genClasses>
       <genClasses image="false" ecoreClass="java.ecore#//members/Method">
         <genOperations ecoreOperation="java.ecore#//members/Method/isMethodForCall"
-            body="return tools.mdsd.jamopp.model.extensions.members.MethodExtension.isMethodForCall((tools.mdsd.jamopp.model.members.Method) this, (tools.mdsd.jamopp.model.references.MethodCall) methodCall, needsPerfectMatch);">
+            body="return tools.mdsd.jamopp.model.java.extensions.members.MethodExtension.isMethodForCall((tools.mdsd.jamopp.model.java.members.Method) this, (tools.mdsd.jamopp.model.java.references.MethodCall) methodCall, needsPerfectMatch);">
           <genParameters ecoreParameter="java.ecore#//members/Method/isMethodForCall/methodCall"/>
           <genParameters ecoreParameter="java.ecore#//members/Method/isMethodForCall/needsPerfectMatch"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//members/Method/isSomeMethodForCall"
-            body="return tools.mdsd.jamopp.model.extensions.members.MethodExtension.isSomeMethodForCall((tools.mdsd.jamopp.model.members.Method) this, (tools.mdsd.jamopp.model.references.MethodCall) methodCall);">
+            body="return tools.mdsd.jamopp.model.java.extensions.members.MethodExtension.isSomeMethodForCall((tools.mdsd.jamopp.model.java.members.Method) this, (tools.mdsd.jamopp.model.java.references.MethodCall) methodCall);">
           <genParameters ecoreParameter="java.ecore#//members/Method/isSomeMethodForCall/methodCall"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//members/Method/isBetterMethodForCall"
-            body="return tools.mdsd.jamopp.model.extensions.members.MethodExtension.isBetterMethodForCall((tools.mdsd.jamopp.model.members.Method) this, (tools.mdsd.jamopp.model.members.Method) otherMethod, (tools.mdsd.jamopp.model.references.MethodCall) methodCall);">
+            body="return tools.mdsd.jamopp.model.java.extensions.members.MethodExtension.isBetterMethodForCall((tools.mdsd.jamopp.model.java.members.Method) this, (tools.mdsd.jamopp.model.java.members.Method) otherMethod, (tools.mdsd.jamopp.model.java.references.MethodCall) methodCall);">
           <genParameters ecoreParameter="java.ecore#//members/Method/isBetterMethodForCall/otherMethod"/>
           <genParameters ecoreParameter="java.ecore#//members/Method/isBetterMethodForCall/methodCall"/>
         </genOperations>
-        <genOperations ecoreOperation="java.ecore#//members/Method/getBlock" body="return tools.mdsd.jamopp.model.extensions.members.MethodExtension.getBlock((tools.mdsd.jamopp.model.members.Method) this);"/>
+        <genOperations ecoreOperation="java.ecore#//members/Method/getBlock" body="return tools.mdsd.jamopp.model.java.extensions.members.MethodExtension.getBlock((tools.mdsd.jamopp.model.java.members.Method) this);"/>
         <genOperations ecoreOperation="java.ecore#//members/Method/getStatements"
-            body="return tools.mdsd.jamopp.model.extensions.members.MethodExtension.getStatements((tools.mdsd.jamopp.model.members.Method) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.members.MethodExtension.getStatements((tools.mdsd.jamopp.model.java.members.Method) this);"/>
         <genOperations ecoreOperation="java.ecore#//members/Method/isSignatureMatching"
-            body="return tools.mdsd.jamopp.model.extensions.members.MethodExtension.isSignatureMatching((tools.mdsd.jamopp.model.members.Method) this, otherMethod);">
+            body="return tools.mdsd.jamopp.model.java.extensions.members.MethodExtension.isSignatureMatching((tools.mdsd.jamopp.model.java.members.Method) this, otherMethod);">
           <genParameters ecoreParameter="java.ecore#//members/Method/isSignatureMatching/otherMethod"/>
         </genOperations>
       </genClasses>
@@ -664,41 +664,41 @@
         <genFeatures notify="false" createChild="false" propertySortChoices="true"
             ecoreFeature="ecore:EReference java.ecore#//modifiers/AnnotableAndModifiable/annotationsAndModifiers"/>
         <genOperations ecoreOperation="java.ecore#//modifiers/AnnotableAndModifiable/isHidden"
-            body="return tools.mdsd.jamopp.model.extensions.modifiers.AnnotableAndModifiableExtension.isHidden((tools.mdsd.jamopp.model.modifiers.AnnotableAndModifiable) this, (tools.mdsd.jamopp.model.commons.Commentable) context);">
+            body="return tools.mdsd.jamopp.model.java.extensions.modifiers.AnnotableAndModifiableExtension.isHidden((tools.mdsd.jamopp.model.java.modifiers.AnnotableAndModifiable) this, (tools.mdsd.jamopp.model.java.commons.Commentable) context);">
           <genParameters ecoreParameter="java.ecore#//modifiers/AnnotableAndModifiable/isHidden/context"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//modifiers/AnnotableAndModifiable/isStatic"
-            body="return tools.mdsd.jamopp.model.extensions.modifiers.AnnotableAndModifiableExtension.isStatic((tools.mdsd.jamopp.model.modifiers.AnnotableAndModifiable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.modifiers.AnnotableAndModifiableExtension.isStatic((tools.mdsd.jamopp.model.java.modifiers.AnnotableAndModifiable) this);"/>
         <genOperations ecoreOperation="java.ecore#//modifiers/AnnotableAndModifiable/removeModifier"
-            body="tools.mdsd.jamopp.model.extensions.modifiers.AnnotableAndModifiableExtension.removeModifier((tools.mdsd.jamopp.model.modifiers.AnnotableAndModifiable) this, modifierType);">
+            body="tools.mdsd.jamopp.model.java.extensions.modifiers.AnnotableAndModifiableExtension.removeModifier((tools.mdsd.jamopp.model.java.modifiers.AnnotableAndModifiable) this, modifierType);">
           <genParameters ecoreParameter="java.ecore#//modifiers/AnnotableAndModifiable/removeModifier/modifierType"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//modifiers/AnnotableAndModifiable/makePublic"
-            body="tools.mdsd.jamopp.model.extensions.modifiers.AnnotableAndModifiableExtension.makePublic((tools.mdsd.jamopp.model.modifiers.AnnotableAndModifiable) this);"/>
+            body="tools.mdsd.jamopp.model.java.extensions.modifiers.AnnotableAndModifiableExtension.makePublic((tools.mdsd.jamopp.model.java.modifiers.AnnotableAndModifiable) this);"/>
         <genOperations ecoreOperation="java.ecore#//modifiers/AnnotableAndModifiable/makePrivate"
-            body="tools.mdsd.jamopp.model.extensions.modifiers.AnnotableAndModifiableExtension.makePrivate((tools.mdsd.jamopp.model.modifiers.AnnotableAndModifiable) this);"/>
+            body="tools.mdsd.jamopp.model.java.extensions.modifiers.AnnotableAndModifiableExtension.makePrivate((tools.mdsd.jamopp.model.java.modifiers.AnnotableAndModifiable) this);"/>
         <genOperations ecoreOperation="java.ecore#//modifiers/AnnotableAndModifiable/makeProtected"
-            body="tools.mdsd.jamopp.model.extensions.modifiers.AnnotableAndModifiableExtension.makeProtected((tools.mdsd.jamopp.model.modifiers.AnnotableAndModifiable) this);"/>
+            body="tools.mdsd.jamopp.model.java.extensions.modifiers.AnnotableAndModifiableExtension.makeProtected((tools.mdsd.jamopp.model.java.modifiers.AnnotableAndModifiable) this);"/>
         <genOperations ecoreOperation="java.ecore#//modifiers/AnnotableAndModifiable/getModifiers"
-            body="return tools.mdsd.jamopp.model.extensions.modifiers.AnnotableAndModifiableExtension.getModifiers((tools.mdsd.jamopp.model.modifiers.AnnotableAndModifiable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.modifiers.AnnotableAndModifiableExtension.getModifiers((tools.mdsd.jamopp.model.java.modifiers.AnnotableAndModifiable) this);"/>
         <genOperations ecoreOperation="java.ecore#//modifiers/AnnotableAndModifiable/removeAllModifiers"
-            body="tools.mdsd.jamopp.model.extensions.modifiers.AnnotableAndModifiableExtension.removeAllModifiers((tools.mdsd.jamopp.model.modifiers.AnnotableAndModifiable) this);"/>
+            body="tools.mdsd.jamopp.model.java.extensions.modifiers.AnnotableAndModifiableExtension.removeAllModifiers((tools.mdsd.jamopp.model.java.modifiers.AnnotableAndModifiable) this);"/>
         <genOperations ecoreOperation="java.ecore#//modifiers/AnnotableAndModifiable/hasModifier"
-            body="return tools.mdsd.jamopp.model.extensions.modifiers.AnnotableAndModifiableExtension.hasModifier((tools.mdsd.jamopp.model.modifiers.AnnotableAndModifiable) this, type);">
+            body="return tools.mdsd.jamopp.model.java.extensions.modifiers.AnnotableAndModifiableExtension.hasModifier((tools.mdsd.jamopp.model.java.modifiers.AnnotableAndModifiable) this, type);">
           <genParameters ecoreParameter="java.ecore#//modifiers/AnnotableAndModifiable/hasModifier/type"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//modifiers/AnnotableAndModifiable/isPublic"
-            body="return tools.mdsd.jamopp.model.extensions.modifiers.AnnotableAndModifiableExtension.isPublic((tools.mdsd.jamopp.model.modifiers.AnnotableAndModifiable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.modifiers.AnnotableAndModifiableExtension.isPublic((tools.mdsd.jamopp.model.java.modifiers.AnnotableAndModifiable) this);"/>
         <genOperations ecoreOperation="java.ecore#//modifiers/AnnotableAndModifiable/isPrivate"
-            body="return tools.mdsd.jamopp.model.extensions.modifiers.AnnotableAndModifiableExtension.isPrivate((tools.mdsd.jamopp.model.modifiers.AnnotableAndModifiable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.modifiers.AnnotableAndModifiableExtension.isPrivate((tools.mdsd.jamopp.model.java.modifiers.AnnotableAndModifiable) this);"/>
         <genOperations ecoreOperation="java.ecore#//modifiers/AnnotableAndModifiable/isProtected"
-            body="return tools.mdsd.jamopp.model.extensions.modifiers.AnnotableAndModifiableExtension.isProtected((tools.mdsd.jamopp.model.modifiers.AnnotableAndModifiable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.modifiers.AnnotableAndModifiableExtension.isProtected((tools.mdsd.jamopp.model.java.modifiers.AnnotableAndModifiable) this);"/>
         <genOperations ecoreOperation="java.ecore#//modifiers/AnnotableAndModifiable/addModifier"
-            body="tools.mdsd.jamopp.model.extensions.modifiers.AnnotableAndModifiableExtension.addModifier((tools.mdsd.jamopp.model.modifiers.AnnotableAndModifiable) this, (tools.mdsd.jamopp.model.modifiers.Modifier) newModifier);">
+            body="tools.mdsd.jamopp.model.java.extensions.modifiers.AnnotableAndModifiableExtension.addModifier((tools.mdsd.jamopp.model.java.modifiers.AnnotableAndModifiable) this, (tools.mdsd.jamopp.model.java.modifiers.Modifier) newModifier);">
           <genParameters ecoreParameter="java.ecore#//modifiers/AnnotableAndModifiable/addModifier/newModifier"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//modifiers/AnnotableAndModifiable/getAnnotationInstances"
-            body="return tools.mdsd.jamopp.model.extensions.modifiers.AnnotableAndModifiableExtension.getAnnotationInstances((tools.mdsd.jamopp.model.modifiers.AnnotableAndModifiable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.modifiers.AnnotableAndModifiableExtension.getAnnotationInstances((tools.mdsd.jamopp.model.java.modifiers.AnnotableAndModifiable) this);"/>
       </genClasses>
       <genClasses image="false" ecoreClass="java.ecore#//modifiers/Modifiable">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//modifiers/Modifiable/modifiers"/>
@@ -783,16 +783,16 @@
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//references/Reference/next"/>
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//references/Reference/arraySelectors"/>
         <genOperations ecoreOperation="java.ecore#//references/Reference/getReferencedType"
-            body="return tools.mdsd.jamopp.model.extensions.references.ReferenceExtension.getReferencedType((tools.mdsd.jamopp.model.references.Reference) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.references.ReferenceExtension.getReferencedType((tools.mdsd.jamopp.model.java.references.Reference) this);"/>
         <genOperations ecoreOperation="java.ecore#//references/Reference/getPrevious"
-            body="return tools.mdsd.jamopp.model.extensions.references.ReferenceExtension.getPrevious((tools.mdsd.jamopp.model.references.Reference) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.references.ReferenceExtension.getPrevious((tools.mdsd.jamopp.model.java.references.Reference) this);"/>
         <genOperations ecoreOperation="java.ecore#//references/Reference/getReferencedTypeReference"
-            body="return tools.mdsd.jamopp.model.extensions.references.ReferenceExtension.getReferencedTypeReference((tools.mdsd.jamopp.model.references.Reference) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.references.ReferenceExtension.getReferencedTypeReference((tools.mdsd.jamopp.model.java.references.Reference) this);"/>
       </genClasses>
       <genClasses image="false" ecoreClass="java.ecore#//references/Argumentable">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#//references/Argumentable/arguments"/>
         <genOperations ecoreOperation="java.ecore#//references/Argumentable/getArgumentTypes"
-            body="return tools.mdsd.jamopp.model.extensions.references.ArgumentableExtension.getArgumentTypes((tools.mdsd.jamopp.model.references.Argumentable) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.references.ArgumentableExtension.getArgumentTypes((tools.mdsd.jamopp.model.java.references.Argumentable) this);"/>
       </genClasses>
       <genClasses image="false" ecoreClass="java.ecore#//references/ReferenceableElement"/>
       <genClasses image="false" ecoreClass="java.ecore#//references/ElementReference">
@@ -802,7 +802,7 @@
       </genClasses>
       <genClasses ecoreClass="java.ecore#//references/IdentifierReference">
         <genOperations ecoreOperation="java.ecore#//references/IdentifierReference/getArrayDimension"
-            body="return tools.mdsd.jamopp.model.extensions.expressions.ExpressionExtension.getArrayDimension((tools.mdsd.jamopp.model.expressions.Expression) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.expressions.ExpressionExtension.getArrayDimension((tools.mdsd.jamopp.model.java.expressions.Expression) this);"/>
       </genClasses>
       <genClasses ecoreClass="java.ecore#//references/MethodCall"/>
       <genClasses ecoreClass="java.ecore#//references/ReflectiveClassReference"/>
@@ -827,7 +827,7 @@
       </genClasses>
       <genClasses image="false" ecoreClass="java.ecore#//statements/StatementListContainer">
         <genOperations ecoreOperation="java.ecore#//statements/StatementListContainer/getLocalVariable"
-            body="return tools.mdsd.jamopp.model.extensions.statements.StatementListContainerExtension.getLocalVariable((tools.mdsd.jamopp.model.statements.StatementListContainer) this, name);">
+            body="return tools.mdsd.jamopp.model.java.extensions.statements.StatementListContainerExtension.getLocalVariable((tools.mdsd.jamopp.model.java.statements.StatementListContainer) this, name);">
           <genParameters ecoreParameter="java.ecore#//statements/StatementListContainer/getLocalVariable/name"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//statements/StatementListContainer/getStatements"/>
@@ -850,7 +850,7 @@
       <genClasses ecoreClass="java.ecore#_Wo2ZD9z1Ed2bJ_pQViWxFg">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#_Wo2ZEdz1Ed2bJ_pQViWxFg"/>
         <genOperations ecoreOperation="java.ecore#//statements/CatchBlock/getStatements"
-            body="return tools.mdsd.jamopp.model.extensions.statements.CatchBlockExtension.getStatements((tools.mdsd.jamopp.model.statements.CatchBlock) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.statements.CatchBlockExtension.getStatements((tools.mdsd.jamopp.model.java.statements.CatchBlock) this);"/>
       </genClasses>
       <genClasses ecoreClass="java.ecore#_Wo2Y1Nz1Ed2bJ_pQViWxFg">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#_Wo2Y2tz1Ed2bJ_pQViWxFg"/>
@@ -891,7 +891,7 @@
       <genClasses ecoreClass="java.ecore#_Wo2ZFdz1Ed2bJ_pQViWxFg">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#_Wo2ZF9z1Ed2bJ_pQViWxFg"/>
         <genOperations ecoreOperation="java.ecore#//statements/SynchronizedBlock/getStatements"
-            body="return tools.mdsd.jamopp.model.extensions.statements.SynchronizedBlockExtension.getStatements((tools.mdsd.jamopp.model.statements.SynchronizedBlock) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.statements.SynchronizedBlockExtension.getStatements((tools.mdsd.jamopp.model.java.statements.SynchronizedBlock) this);"/>
       </genClasses>
       <genClasses ecoreClass="java.ecore#_Wo2ZH9z1Ed2bJ_pQViWxFg">
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#_Wo2ZIdz1Ed2bJ_pQViWxFg"/>
@@ -901,9 +901,9 @@
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#_Wo2ZDtz1Ed2bJ_pQViWxFg"/>
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference java.ecore#_Wo2ZDNz1Ed2bJ_pQViWxFg"/>
         <genOperations ecoreOperation="java.ecore#//statements/TryBlock/getCatcheBlocks"
-            body="return tools.mdsd.jamopp.model.extensions.statements.TryBlockExtension.getCatcheBlocks((tools.mdsd.jamopp.model.statements.TryBlock) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.statements.TryBlockExtension.getCatcheBlocks((tools.mdsd.jamopp.model.java.statements.TryBlock) this);"/>
         <genOperations ecoreOperation="java.ecore#//statements/TryBlock/getStatements"
-            body="return tools.mdsd.jamopp.model.extensions.statements.TryBlockExtension.getStatements((tools.mdsd.jamopp.model.statements.TryBlock) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.statements.TryBlockExtension.getStatements((tools.mdsd.jamopp.model.java.statements.TryBlock) this);"/>
       </genClasses>
       <genClasses ecoreClass="java.ecore#_Wo2ZANz1Ed2bJ_pQViWxFg"/>
       <genClasses image="false" ecoreClass="java.ecore#//statements/BlockContainer">
@@ -921,12 +921,12 @@
     <nestedGenPackages prefix="Types" basePackage="tools.mdsd.jamopp.model.java" disposableProviderFactory="true"
         ecorePackage="java.ecore#_Wo2ZOtz1Ed2bJ_pQViWxFg">
       <genClasses image="false" ecoreClass="java.ecore#_Wo2ZO9z1Ed2bJ_pQViWxFg">
-        <genOperations ecoreOperation="java.ecore#//types/Type/equalsType" body="return tools.mdsd.jamopp.model.extensions.types.TypeExtension.equalsType((tools.mdsd.jamopp.model.types.Type) this, arrayDimension, (tools.mdsd.jamopp.model.types.Type) otherType, otherArrayDimension);">
+        <genOperations ecoreOperation="java.ecore#//types/Type/equalsType" body="return tools.mdsd.jamopp.model.java.extensions.types.TypeExtension.equalsType((tools.mdsd.jamopp.model.java.types.Type) this, arrayDimension, (tools.mdsd.jamopp.model.java.types.Type) otherType, otherArrayDimension);">
           <genParameters ecoreParameter="java.ecore#//types/Type/equalsType/arrayDimension"/>
           <genParameters ecoreParameter="java.ecore#//types/Type/equalsType/otherType"/>
           <genParameters ecoreParameter="java.ecore#//types/Type/equalsType/otherArrayDimension"/>
         </genOperations>
-        <genOperations ecoreOperation="java.ecore#//types/Type/isSuperType" body="return tools.mdsd.jamopp.model.extensions.types.TypeExtension.isSuperType((tools.mdsd.jamopp.model.types.Type) this, arrayDimension, (tools.mdsd.jamopp.model.types.Type) otherType, (tools.mdsd.jamopp.model.arrays.ArrayTypeable) otherArrayType);">
+        <genOperations ecoreOperation="java.ecore#//types/Type/isSuperType" body="return tools.mdsd.jamopp.model.java.extensions.types.TypeExtension.isSuperType((tools.mdsd.jamopp.model.java.types.Type) this, arrayDimension, (tools.mdsd.jamopp.model.java.types.Type) otherType, (tools.mdsd.jamopp.model.java.arrays.ArrayTypeable) otherArrayType);">
           <genParameters ecoreParameter="java.ecore#//types/Type/isSuperType/arrayDimension"/>
           <genParameters ecoreParameter="java.ecore#//types/Type/isSuperType/otherType"/>
           <genParameters ecoreParameter="java.ecore#//types/Type/isSuperType/otherArrayType"/>
@@ -943,19 +943,19 @@
       </genClasses>
       <genClasses image="false" ecoreClass="java.ecore#_Wo2ZPdz1Ed2bJ_pQViWxFg">
         <genOperations ecoreOperation="java.ecore#//types/TypeReference/getTarget"
-            body="return tools.mdsd.jamopp.model.extensions.types.TypeReferenceExtension.getBoundTarget((tools.mdsd.jamopp.model.types.TypeReference) this, null);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.types.TypeReferenceExtension.getBoundTarget((tools.mdsd.jamopp.model.java.types.TypeReference) this, null);"/>
         <genOperations ecoreOperation="java.ecore#//types/TypeReference/setTarget"
-            body="tools.mdsd.jamopp.model.extensions.types.TypeReferenceExtension.setTarget((tools.mdsd.jamopp.model.types.TypeReference) this, (tools.mdsd.jamopp.model.classifiers.Classifier) type);">
+            body="tools.mdsd.jamopp.model.java.extensions.types.TypeReferenceExtension.setTarget((tools.mdsd.jamopp.model.java.types.TypeReference) this, (tools.mdsd.jamopp.model.java.classifiers.Classifier) type);">
           <genParameters ecoreParameter="java.ecore#//types/TypeReference/setTarget/type"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//types/TypeReference/getBoundTarget"
-            body="return tools.mdsd.jamopp.model.extensions.types.TypeReferenceExtension.getBoundTarget((tools.mdsd.jamopp.model.types.TypeReference) this, (tools.mdsd.jamopp.model.references.Reference) reference);">
+            body="return tools.mdsd.jamopp.model.java.extensions.types.TypeReferenceExtension.getBoundTarget((tools.mdsd.jamopp.model.java.types.TypeReference) this, (tools.mdsd.jamopp.model.java.references.Reference) reference);">
           <genParameters ecoreParameter="java.ecore#//types/TypeReference/getBoundTarget/reference"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//types/TypeReference/getPureClassifierReference"
-            body="return tools.mdsd.jamopp.model.extensions.types.TypeReferenceExtension.getPureClassifierReference((tools.mdsd.jamopp.model.types.TypeReference) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.types.TypeReferenceExtension.getPureClassifierReference((tools.mdsd.jamopp.model.java.types.TypeReference) this);"/>
         <genOperations ecoreOperation="java.ecore#//types/TypeReference/getBoundTargetReference"
-            body="return tools.mdsd.jamopp.model.extensions.types.TypeReferenceExtension.getBoundTargetReference((tools.mdsd.jamopp.model.types.TypeReference) this, reference);">
+            body="return tools.mdsd.jamopp.model.java.extensions.types.TypeReferenceExtension.getBoundTargetReference((tools.mdsd.jamopp.model.java.types.TypeReference) this, reference);">
           <genParameters ecoreParameter="java.ecore#//types/TypeReference/getBoundTargetReference/reference"/>
         </genOperations>
       </genClasses>
@@ -968,11 +968,11 @@
       </genClasses>
       <genClasses image="false" ecoreClass="java.ecore#_Wo2ZR9z1Ed2bJ_pQViWxFg">
         <genOperations ecoreOperation="java.ecore#//types/PrimitiveType/getAllMembers"
-            body="return tools.mdsd.jamopp.model.extensions.types.PrimitiveTypeExtension.getAllMembers((tools.mdsd.jamopp.model.types.PrimitiveType) this, (tools.mdsd.jamopp.model.commons.Commentable) context);">
+            body="return tools.mdsd.jamopp.model.java.extensions.types.PrimitiveTypeExtension.getAllMembers((tools.mdsd.jamopp.model.java.types.PrimitiveType) this, (tools.mdsd.jamopp.model.java.commons.Commentable) context);">
           <genParameters ecoreParameter="java.ecore#//types/PrimitiveType/getAllMembers/context"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//types/PrimitiveType/wrapPrimitiveType"
-            body="return tools.mdsd.jamopp.model.extensions.types.PrimitiveTypeExtension.wrapPrimitiveType((tools.mdsd.jamopp.model.types.PrimitiveType) this);"/>
+            body="return tools.mdsd.jamopp.model.java.extensions.types.PrimitiveTypeExtension.wrapPrimitiveType((tools.mdsd.jamopp.model.java.types.PrimitiveType) this);"/>
       </genClasses>
       <genClasses ecoreClass="java.ecore#_Wo2ZS9z1Ed2bJ_pQViWxFg"/>
       <genClasses ecoreClass="java.ecore#_Wo2ZT9z1Ed2bJ_pQViWxFg"/>
@@ -985,7 +985,7 @@
       <genClasses ecoreClass="java.ecore#//types/Void"/>
       <genClasses ecoreClass="java.ecore#//types/InferableType">
         <genOperations ecoreOperation="java.ecore#//types/InferableType/getBoundTargetReference"
-            body="return tools.mdsd.jamopp.model.extensions.types.InferableTypeExtension.getBoundTargetReference((tools.mdsd.jamopp.model.types.InferableType) this, reference);">
+            body="return tools.mdsd.jamopp.model.java.extensions.types.InferableTypeExtension.getBoundTargetReference((tools.mdsd.jamopp.model.java.types.InferableType) this, reference);">
           <genParameters ecoreParameter="java.ecore#//types/InferableType/getBoundTargetReference/reference"/>
         </genOperations>
       </genClasses>
@@ -994,12 +994,12 @@
         disposableProviderFactory="true" ecorePackage="java.ecore#//variables">
       <genClasses image="false" ecoreClass="java.ecore#//variables/Variable">
         <genOperations ecoreOperation="java.ecore#//variables/Variable/createMethodCallStatement"
-            body="return tools.mdsd.jamopp.model.extensions.variables.VariableExtension.createMethodCallStatement((tools.mdsd.jamopp.model.variables.Variable) this, methodName, arguments);">
+            body="return tools.mdsd.jamopp.model.java.extensions.variables.VariableExtension.createMethodCallStatement((tools.mdsd.jamopp.model.java.variables.Variable) this, methodName, arguments);">
           <genParameters ecoreParameter="java.ecore#//variables/Variable/createMethodCallStatement/methodName"/>
           <genParameters ecoreParameter="java.ecore#//variables/Variable/createMethodCallStatement/arguments"/>
         </genOperations>
         <genOperations ecoreOperation="java.ecore#//variables/Variable/createMethodCall"
-            body="return tools.mdsd.jamopp.model.extensions.variables.VariableExtension.createMethodCall((tools.mdsd.jamopp.model.variables.Variable) this, methodName, arguments);">
+            body="return tools.mdsd.jamopp.model.java.extensions.variables.VariableExtension.createMethodCall((tools.mdsd.jamopp.model.java.variables.Variable) this, methodName, arguments);">
           <genParameters ecoreParameter="java.ecore#//variables/Variable/createMethodCall/methodName"/>
           <genParameters ecoreParameter="java.ecore#//variables/Variable/createMethodCall/arguments"/>
         </genOperations>

--- a/jamopp.model/src/main/resources/plugin.properties
+++ b/jamopp.model/src/main/resources/plugin.properties
@@ -1,3 +1,6 @@
+# Copyright (c) 2020-2023
+# Modelling for Continuous Software Engineering (MCSE) group, Institute of Information Security and Dependability (KASTEL), Karlsruhe Institute of Technology (KIT).
+# 
 # Copyright (c) 2006-2014
 # Software Technology Group, Dresden University of Technology
 # DevBoost GmbH, Berlin, Amtsgericht Charlottenburg, HRB 140026
@@ -11,9 +14,9 @@
 #   Software Technology Group - TU Dresden, Germany;
 #   DevBoost GmbH - Berlin, Germany
 #      - initial API and implementation
-#   Martin Armbruster
-#      - Extension for Java 7-13
+#   Martin Armbruster (MCSE, KASTEL, KIT)
+#      - Adaptation and extension for Java 7+
 #  
 
-pluginName = JaMoPP (Java Model Parser and Printer) Metamodel
-providerName = Martin Armbruster
+pluginName = Java Model
+providerName = www.example.org

--- a/jamopp.model/src/main/resources/plugin.xml
+++ b/jamopp.model/src/main/resources/plugin.xml
@@ -2,7 +2,10 @@
 <?eclipse version="3.0"?>
 
 <!--
- Copyright (c) 2006-2015
+ Copyright (c) 2020-2023
+ Modelling for Continuous Software Engineering (MCSE) group, Institute of Information Security and Dependability (KASTEL), Karlsruhe Institute of Technology (KIT).
+ 
+ Copyright (c) 2006-2014
  Software Technology Group, Dresden University of Technology
  DevBoost GmbH, Berlin, Amtsgericht Charlottenburg, HRB 140026
  
@@ -15,156 +18,178 @@
    Software Technology Group - TU Dresden, Germany;
    DevBoost GmbH - Berlin, Germany
       - initial API and implementation
+   Martin Armbruster (MCSE, KASTEL, KIT)
+      - Adaptation and extension for Java 7+
   
 -->
 
 <plugin>
-   <extension point="org.eclipse.emf.ecore.generated_package">
-      <package
-            uri="http://www.emftext.org/java"
-            class="org.emftext.language.java.JavaPackage"
-            genModel="metamodel/java.genmodel"/>
-   </extension>
-   
-   <extension point="org.eclipse.emf.ecore.generated_package">
-      <package
-            uri="http://www.emftext.org/java/annotations"
-            class="org.emftext.language.java.annotations.AnnotationsPackage"
-            genModel="metamodel/java.genmodel"/>
-   </extension>
 
-   <extension point="org.eclipse.emf.ecore.generated_package">
+	<extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
       <package
-            uri="http://www.emftext.org/java/imports"
-            class="org.emftext.language.java.imports.ImportsPackage"
-            genModel="metamodel/java.genmodel"/>
-   </extension>
-
-   <extension point="org.eclipse.emf.ecore.generated_package">
-      <package
-            uri="http://www.emftext.org/java/references"
-            class="org.emftext.language.java.references.ReferencesPackage"
-            genModel="metamodel/java.genmodel"/>
-   </extension>
-
-   <extension point="org.eclipse.emf.ecore.generated_package">
-      <package
-            uri="http://www.emftext.org/java/generics"
-            class="org.emftext.language.java.generics.GenericsPackage"
-            genModel="metamodel/java.genmodel"/>
-   </extension>
-
-   <extension point="org.eclipse.emf.ecore.generated_package">
-      <package
-            uri="http://www.emftext.org/java/arrays"
-            class="org.emftext.language.java.arrays.ArraysPackage"
-            genModel="metamodel/java.genmodel"/>
-   </extension>
-
-   <extension point="org.eclipse.emf.ecore.generated_package">
-      <package
-            uri="http://www.emftext.org/java/classifiers"
-            class="org.emftext.language.java.classifiers.ClassifiersPackage"
-            genModel="metamodel/java.genmodel"/>
-   </extension>
-
-   <extension point="org.eclipse.emf.ecore.generated_package">
-      <package
-            uri="http://www.emftext.org/java/containers"
-            class="org.emftext.language.java.containers.ContainersPackage"
-            genModel="metamodel/java.genmodel"/>
-   </extension>
-
-   <extension point="org.eclipse.emf.ecore.generated_package">
-      <package
-            uri="http://www.emftext.org/java/instantiations"
-            class="org.emftext.language.java.instantiations.InstantiationsPackage"
-            genModel="metamodel/java.genmodel"/>
-   </extension>
-
-   <extension point="org.eclipse.emf.ecore.generated_package">
-      <package
-            uri="http://www.emftext.org/java/parameters"
-            class="org.emftext.language.java.parameters.ParametersPackage"
-            genModel="metamodel/java.genmodel"/>
-   </extension>
-
-   <extension point="org.eclipse.emf.ecore.generated_package">
-      <package
-            uri="http://www.emftext.org/java/variables"
-            class="org.emftext.language.java.variables.VariablesPackage"
+            uri="https://mdsd.tools/jamopp/6.0.0/java"
+            class="tools.mdsd.jamopp.model.java.JavaPackage"
             genModel="metamodel/java.genmodel"/>
    </extension>
 
    <extension point="org.eclipse.emf.ecore.generated_package">
       <!-- @generated java -->
       <package
-            uri="http://www.emftext.org/java/modules"
-            class="org.emftext.language.java.modules.ModulesPackage"
+            uri="https://mdsd.tools/jamopp/6.0.0/java/annotations"
+            class="tools.mdsd.jamopp.model.java.annotations.AnnotationsPackage"
             genModel="metamodel/java.genmodel"/>
    </extension>
 
    <extension point="org.eclipse.emf.ecore.generated_package">
       <!-- @generated java -->
       <package
-            uri="http://www.emftext.org/commons/layout"
-            class="org.emftext.commons.layout.LayoutPackage"
+            uri="https://mdsd.tools/jamopp/6.0.0/java/arrays"
+            class="tools.mdsd.jamopp.model.java.arrays.ArraysPackage"
             genModel="metamodel/java.genmodel"/>
    </extension>
 
    <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
       <package
-            uri="http://www.emftext.org/java/members"
-            class="org.emftext.language.java.members.MembersPackage"
+            uri="https://mdsd.tools/jamopp/6.0.0/java/classifiers"
+            class="tools.mdsd.jamopp.model.java.classifiers.ClassifiersPackage"
             genModel="metamodel/java.genmodel"/>
    </extension>
 
    <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
       <package
-            uri="http://www.emftext.org/java/commons"
-            class="org.emftext.language.java.commons.CommonsPackage"
+            uri="https://mdsd.tools/jamopp/6.0.0/java/commons"
+            class="tools.mdsd.jamopp.model.java.commons.CommonsPackage"
             genModel="metamodel/java.genmodel"/>
    </extension>
 
    <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
       <package
-            uri="http://www.emftext.org/java/expressions"
-            class="org.emftext.language.java.expressions.ExpressionsPackage"
+            uri="https://mdsd.tools/jamopp/6.0.0/java/containers"
+            class="tools.mdsd.jamopp.model.java.containers.ContainersPackage"
             genModel="metamodel/java.genmodel"/>
    </extension>
 
    <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
       <package
-            uri="http://www.emftext.org/java/operators"
-            class="org.emftext.language.java.operators.OperatorsPackage"
+            uri="https://mdsd.tools/jamopp/6.0.0/java/expressions"
+            class="tools.mdsd.jamopp.model.java.expressions.ExpressionsPackage"
             genModel="metamodel/java.genmodel"/>
    </extension>
 
    <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
       <package
-            uri="http://www.emftext.org/java/literals"
-            class="org.emftext.language.java.literals.LiteralsPackage"
+            uri="https://mdsd.tools/jamopp/6.0.0/java/generics"
+            class="tools.mdsd.jamopp.model.java.generics.GenericsPackage"
             genModel="metamodel/java.genmodel"/>
    </extension>
 
    <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
       <package
-            uri="http://www.emftext.org/java/modifiers"
-            class="org.emftext.language.java.modifiers.ModifiersPackage"
+            uri="https://mdsd.tools/jamopp/6.0.0/java/imports"
+            class="tools.mdsd.jamopp.model.java.imports.ImportsPackage"
             genModel="metamodel/java.genmodel"/>
    </extension>
 
    <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
       <package
-            uri="http://www.emftext.org/java/statements"
-            class="org.emftext.language.java.statements.StatementsPackage"
+            uri="https://mdsd.tools/jamopp/6.0.0/java/instantiations"
+            class="tools.mdsd.jamopp.model.java.instantiations.InstantiationsPackage"
             genModel="metamodel/java.genmodel"/>
    </extension>
 
    <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
       <package
-            uri="http://www.emftext.org/java/types"
-            class="org.emftext.language.java.types.TypesPackage"
+            uri="https://mdsd.tools/jamopp/6.0.0/java/literals"
+            class="tools.mdsd.jamopp.model.java.literals.LiteralsPackage"
+            genModel="metamodel/java.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
+      <package
+            uri="https://mdsd.tools/jamopp/6.0.0/java/members"
+            class="tools.mdsd.jamopp.model.java.members.MembersPackage"
+            genModel="metamodel/java.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
+      <package
+            uri="https://mdsd.tools/jamopp/6.0.0/java/modifiers"
+            class="tools.mdsd.jamopp.model.java.modifiers.ModifiersPackage"
+            genModel="metamodel/java.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
+      <package
+            uri="https://mdsd.tools/jamopp/6.0.0/java/operators"
+            class="tools.mdsd.jamopp.model.java.operators.OperatorsPackage"
+            genModel="metamodel/java.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
+      <package
+            uri="https://mdsd.tools/jamopp/6.0.0/java/parameters"
+            class="tools.mdsd.jamopp.model.java.parameters.ParametersPackage"
+            genModel="metamodel/java.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
+      <package
+            uri="https://mdsd.tools/jamopp/6.0.0/java/references"
+            class="tools.mdsd.jamopp.model.java.references.ReferencesPackage"
+            genModel="metamodel/java.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
+      <package
+            uri="https://mdsd.tools/jamopp/6.0.0/java/statements"
+            class="tools.mdsd.jamopp.model.java.statements.StatementsPackage"
+            genModel="metamodel/java.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
+      <package
+            uri="https://mdsd.tools/jamopp/6.0.0/java/types"
+            class="tools.mdsd.jamopp.model.java.types.TypesPackage"
+            genModel="metamodel/java.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
+      <package
+            uri="https://mdsd.tools/jamopp/6.0.0/java/variables"
+            class="tools.mdsd.jamopp.model.java.variables.VariablesPackage"
+            genModel="metamodel/java.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
+      <package
+            uri="https://mdsd.tools/jamopp/6.0.0/java/modules"
+            class="tools.mdsd.jamopp.model.java.modules.ModulesPackage"
+            genModel="metamodel/java.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated java -->
+      <package
+            uri="https://mdsd.tools/jamopp/6.0.0/commons/layout"
+            class="tools.mdsd.jamopp.model.commons.layout.LayoutPackage"
             genModel="metamodel/java.genmodel"/>
    </extension>
 

--- a/jamopp.p2/pom.xml
+++ b/jamopp.p2/pom.xml
@@ -33,11 +33,43 @@
                                 <!-- groupId:artifactId:version -->
                                 <artifact>
                                     <id>tools.mdsd:jamopp.model:6.0.0-SNAPSHOT</id>
+                                    <transitive>false</transitive>
+                                </artifact>
+                                <artifact>
                                     <id>tools.mdsd:jamopp.model.edit:6.0.0-SNAPSHOT</id>
+                                    <transitive>false</transitive>
+                                </artifact>
+                                <artifact>
                                     <id>tools.mdsd:jamopp.parser.jdt.singlefile:6.0.0-SNAPSHOT</id>
+                                    <transitive>false</transitive>
+                                </artifact>
+                                <artifact>
                                     <id>tools.mdsd:jamopp.resource:6.0.0-SNAPSHOT</id>
+                                    <transitive>false</transitive>
+                                </artifact>
+                                <artifact>
                                     <id>tools.mdsd:jamopp.parser.jdt:6.0.0-SNAPSHOT</id>
+                                    <transitive>false</transitive>
+                                </artifact>
+								<artifact>
+                                    <id>tools.mdsd:jamopp.parser.bcel:6.0.0-SNAPSHOT</id>
+                                    <transitive>false</transitive>
+                                </artifact>
+                                <artifact>
                                     <id>tools.mdsd:jamopp.standalone:6.0.0-SNAPSHOT</id>
+                                    <transitive>false</transitive>
+                                </artifact>
+                                <artifact>
+                                    <id>org.apache.logging.log4j:log4j-api:2.20.0</id>
+                                    <transitive>false</transitive>
+                                </artifact>
+                                <artifact>
+                                    <id>org.apache.bcel:bcel:6.7.0</id>
+                                    <transitive>false</transitive>
+                                </artifact>
+                                <artifact>
+                                    <id>org.apache.commons:commons-lang3:3.12.0</id>
+                                    <transitive>false</transitive>
                                 </artifact>
                             </artifacts>
                             <featureDefinitions>

--- a/jamopp.parser.jdt.singlefile/pom.xml
+++ b/jamopp.parser.jdt.singlefile/pom.xml
@@ -57,15 +57,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
-    </dependencies>
+	</dependencies>
 </project>

--- a/jamopp.parser.jdt.singlefile/src/main/java/tools/mdsd/jamopp/parser/jdt/singlefile/JaMoPPJDTSingleFileParser.java
+++ b/jamopp.parser.jdt.singlefile/src/main/java/tools/mdsd/jamopp/parser/jdt/singlefile/JaMoPPJDTSingleFileParser.java
@@ -27,7 +27,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
@@ -51,7 +52,7 @@ import tools.mdsd.jamopp.resolution.bindings.CentralBindingBasedResolver;
 import tools.mdsd.jamopp.resolution.resolver.CentralReferenceResolver;
 
 public class JaMoPPJDTSingleFileParser implements JaMoPPParserAPI {
-	private static final Logger logger = Logger.getLogger("jamopp."
+	private static final Logger logger = LogManager.getLogger("jamopp."
 			+ JaMoPPJDTSingleFileParser.class.getSimpleName());
 	private final String DEFAULT_ENCODING = StandardCharsets.UTF_8.toString();
 	private ResourceSet resourceSet;

--- a/jamopp.resource/pom.xml
+++ b/jamopp.resource/pom.xml
@@ -63,15 +63,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/jamopp.resource/src/main/java/tools/mdsd/jamopp/resource/JavaResource2.java
+++ b/jamopp.resource/src/main/java/tools/mdsd/jamopp/resource/JavaResource2.java
@@ -20,7 +20,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
@@ -48,7 +49,7 @@ import tools.mdsd.jamopp.resolution.resolver.result.IJavaURIMapping;
 
 public class JavaResource2 extends XMIResourceImpl {
 	public static final String JAVAXMI_FILE_EXTENSION = LogicalJavaURIGenerator.JAVAXMI_FILE_EXTENSION_NAME;
-	private static final Logger LOGGER = Logger.getLogger("jamopp." + JavaResource2.class.getSimpleName());
+	private static final Logger LOGGER = LogManager.getLogger("jamopp." + JavaResource2.class.getSimpleName());
 	private Map<String, IJavaContextDependentURIFragment> internalURIFragmentMap =
 			IJavaContextDependentURIFragmentCollector.GLOBAL_INSTANCE
 			.getContextDependentURIFragmentMap();

--- a/jamopp.tests/pom.xml
+++ b/jamopp.tests/pom.xml
@@ -105,15 +105,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/jamopp.tests/src/test/java/tools/mdsd/jamopp/test/AbstractJaMoPPTests.java
+++ b/jamopp.tests/src/test/java/tools/mdsd/jamopp/test/AbstractJaMoPPTests.java
@@ -46,10 +46,10 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import org.apache.log4j.ConsoleAppender;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.log4j.PatternLayout;
+//import org.apache.log4j.ConsoleAppender;
+//import org.apache.log4j.Level;
+//import org.apache.log4j.Logger;
+//import org.apache.log4j.PatternLayout;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
@@ -102,8 +102,8 @@ public abstract class AbstractJaMoPPTests {
 
 	@BeforeAll
 	public static void initLogging() {
-		Logger logger = Logger.getLogger("jamopp");
-		logger.setLevel(Level.ALL);
+//		Logger logger = Logger.getLogger("jamopp");
+//		logger.setLevel(Level.ALL);
 //		ConsoleAppender ca = new ConsoleAppender(new PatternLayout("[%d{DATE}] %-5p: %c - %m%n"),
 //				ConsoleAppender.SYSTEM_OUT);
 //		logger.addAppender(ca);

--- a/jamopp.tests/src/test/java/tools/mdsd/jamopp/test/bulk/SingleFileParserBulkTests.java
+++ b/jamopp.tests/src/test/java/tools/mdsd/jamopp/test/bulk/SingleFileParserBulkTests.java
@@ -36,7 +36,8 @@ import java.util.Set;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.apache.commons.compress.archivers.examples.Expander;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.junit.jupiter.api.Disabled;
@@ -48,7 +49,7 @@ import tools.mdsd.jamopp.test.AbstractJaMoPPTests;
 
 @Disabled("Requires initialization of all submodules and dependency resolution.")
 public class SingleFileParserBulkTests extends AbstractJaMoPPTests {
-	private static final Logger LOGGER = Logger.getLogger("jamopp."
+	private static final Logger LOGGER = LogManager.getLogger("jamopp."
 			+ SingleFileParserBulkTests.class.getSimpleName());
 	// TODO: Adjust path.
 	private static final String BASE_ZIP = "JaMoPP-BulkTest" + File.separator + "Tests" + File.separator

--- a/jamopp.tests/src/test/java/tools/mdsd/jamopp/test/performance/PerformanceTest.java
+++ b/jamopp.tests/src/test/java/tools/mdsd/jamopp/test/performance/PerformanceTest.java
@@ -22,7 +22,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.util.EcoreUtil;
@@ -40,7 +41,7 @@ import tools.mdsd.jamopp.test.bulk.SingleFileParserBulkTests;
  */
 @Disabled
 public class PerformanceTest extends AbstractJaMoPPTests {
-	private static final Logger LOGGER = Logger.getLogger("jamopp."
+	private static final Logger LOGGER = LogManager.getLogger("jamopp."
 			+ SingleFileParserBulkTests.class.getSimpleName());
 	private final String inputFolder = "target" + File.separator + "src-bulk" + File.separator + "TeaStore";
 	private final Path parentOutput = Paths.get("output_performance");

--- a/pom.xml
+++ b/pom.xml
@@ -49,29 +49,34 @@
                 <version>3.18.0</version>
             </dependency>
             <dependency>
+			    <groupId>org.eclipse.emf</groupId>
+			    <artifactId>org.eclipse.emf.common</artifactId>
+			    <version>2.26.0</version>
+			</dependency>
+            <dependency>
                 <groupId>org.eclipse.emf</groupId>
                 <artifactId>org.eclipse.emf.ecore</artifactId>
-                <version>2.33.0</version>
+                <version>2.26.0</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.emf</groupId>
                 <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
-                <version>2.18.0</version>
+                <version>2.17.0</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.emf</groupId>
                 <artifactId>org.eclipse.emf.ecore.change</artifactId>
-                <version>2.15.0</version>
+                <version>2.14.0</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.emf</groupId>
                 <artifactId>org.eclipse.emf.codegen.ecore</artifactId>
-                <version>2.33.0</version>
+                <version>2.29.0</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.emf</groupId>
                 <artifactId>org.eclipse.emf.edit</artifactId>
-                <version>2.18.0</version>
+                <version>2.17.0</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.emf</groupId>
@@ -96,7 +101,7 @@
             <dependency>
                 <groupId>org.eclipse.jdt</groupId>
                 <artifactId>org.eclipse.jdt.core</artifactId>
-                <version>3.33.0</version>
+                <version>3.32.0</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
This PR:
- downgrades some dependencies so that the extended JaMoPP is compatible with Eclipse 2022-12.
- versions the meta-model.
- excludes some Eclipse dependencies from the P2 repository to avoid conflicts when installing the extended JaMoPP in Eclipse.